### PR TITLE
Support inline editing for authors and affiliations 

### DIFF
--- a/src/editor/components/AffiliationsListComponent.js
+++ b/src/editor/components/AffiliationsListComponent.js
@@ -1,4 +1,4 @@
-import { Component } from 'substance'
+import { Component, TextPropertyEditor } from 'substance'
 
 export default class AffiliationsList extends Component {
 
@@ -15,22 +15,43 @@ export default class AffiliationsList extends Component {
   render($$) {
     const articleMeta = this.props.node
     const affiliations = articleMeta.findAll('string-aff')
-    const affs = affiliations.map(aff => { return aff.getTextContent() })
-    
-    let el = $$('div').addClass('sc-affiliations-list')
-      .append(affs.join('; '))
+    let els = [];
 
-    return el
+    let affiliationsEl = affiliations.map(affiliation => {
+      return $$(TextPropertyEditor, {
+        placeholder: 'Enter affiliated institution',
+        path: affiliation.getTextPath(),
+        disabled: this.props.disabled,
+        tagName: 'span'
+      }).addClass('se-affiliation')
+    })
+
+    // Separate affiliations with a semi-colon
+    // TODO this should be translatable
+    for (let affiliationEl of affiliationsEl) {
+      els.push(affiliationEl, $$('span').append(';').addClass('se-separator'))
+    }
+    els = els.slice(0, -1)
+
+    return $$('div').addClass('sc-affiliations-list')
+      .append(els)
+      .on('click', this._editAffiliations)
   }
 
   _onDocumentChange(change) {
     let updatedProps = Object.keys(change.updated)
     let updatedPropsString = updatedProps.join('/')
-    // We will trigger rerendering if any string-aff 
+    // We will trigger rerendering if any string-aff
     // or aff-group were updated
     if(updatedPropsString.indexOf('string-aff') > -1 || updatedPropsString.indexOf('aff-group') > -1) {
       this.rerender()
-    } 
+    }
+  }
+
+  _editAffiliations() {
+    this.send('switchContext', {
+      contextId: 'affiliations',
+    })
   }
 
 }

--- a/src/editor/components/AuthorsListComponent.js
+++ b/src/editor/components/AuthorsListComponent.js
@@ -1,4 +1,4 @@
-import { Component } from 'substance'
+import { Component, TextPropertyEditor } from 'substance'
 
 export default class AuthorsListComponent extends Component {
 
@@ -15,22 +15,42 @@ export default class AuthorsListComponent extends Component {
   render($$) {
     const articleMeta = this.props.node
     const contribs = articleMeta.findAll('string-contrib')
-    const authors = contribs.map(contrib => { return contrib.getTextContent() })
-    
-    let el = $$('div').addClass('sc-authors-list')
-      .append(authors.join(', '))
+    let els = [];
 
-    return el
+    let contribsEls = contribs.map(contrib => {
+      return $$(TextPropertyEditor, {
+        placeholder: 'Enter author name',
+        path: contrib.getTextPath(),
+        disabled: this.props.disabled,
+        tagName: 'span'
+      }).addClass('se-author')
+    })
+
+    // Separate contributors with a comma
+    // TODO this should be translatable
+    for (let contribsEl of contribsEls) {
+      els.push(contribsEl, $$('span').append(',').addClass('se-separator'))
+    }
+    els = els.slice(0, -1)
+
+    return $$('div').addClass('sc-authors-list')
+      .append(els)
+      .on('click', this._editContributors)
   }
 
   _onDocumentChange(change) {
     let updatedProps = Object.keys(change.updated)
     let updatedPropsString = updatedProps.join('/')
-    // We will trigger rerendering if any string-contrib 
+    // We will trigger rerendering if any string-contrib
     // or contrib-group was updated
     if(updatedPropsString.indexOf('string-contrib') > -1 || updatedPropsString.indexOf('contrib-group') > -1) {
       this.rerender()
-    } 
+    }
   }
 
+  _editContributors() {
+    this.send('switchContext', {
+      contextId: 'contributors',
+    })
+  }
 }

--- a/src/editor/styles/_affiliations-list.css
+++ b/src/editor/styles/_affiliations-list.css
@@ -5,3 +5,11 @@
   font-size: 16px;
   font-weight: 500;
 }
+
+.sc-affiliations-list .se-affiliation {
+  display: inline-block;
+}
+
+.sc-affiliations-list .se-separator + .se-affiliation {
+  margin-left: 0.25em;
+}

--- a/src/editor/styles/_authors-list.css
+++ b/src/editor/styles/_authors-list.css
@@ -5,3 +5,11 @@
   font-size: 20px;
   font-weight: 500;
 }
+
+.sc-authors-list .se-author {
+  display: inline-block;
+}
+
+.sc-authors-list .se-separator + .se-author {
+  margin-left: 0.25em;
+}

--- a/src/editor/styles/_contributors.css
+++ b/src/editor/styles/_contributors.css
@@ -49,5 +49,5 @@
 }
 
 .sc-contributors .sc-multi-select {
-  padding: 10px;
+  width: 200px;
 }


### PR DESCRIPTION
Here's a start on some work for authors and affiliations. It allows them to be edited inline and opens the associated panel on the right when doing so.

Further considerations:
- It'd be nice to link authors to their affiliations. I think usually reference numbers like `Jane Doe<sup>1</sup> <sup>2</sup>` are used for this.
- The `,` and `;` separators should be translatable.
- Since `,` and `;` are used as separators, should we prevent their use within these fields? If so, would that entail an extended `TextPropertyEditor` with some event listeners or is there already some facility for listening to events on a `TextPropertyEditor`?