### PR TITLE
Strict schema + transformers for <disp-quote>.

### DIFF
--- a/data/kitchen-sink.xml
+++ b/data/kitchen-sink.xml
@@ -109,10 +109,9 @@
         </fig>
         <disp-quote>
           <p>Curabitur vehicula mattis sodales. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Sed id nulla eget neque laoreet cursus id non urna. Aenean felis massa, mattis non laoreet ut, ultrices et velit. Fusce imperdiet auctor porttitor. Maecenas sed varius est. Etiam auctor consequat nunc quis pretium. Fusce sollicitudin euismod nisl, id ullamcorper leo. Nunc interdum, nisl sit amet gravida interdum, nibh nunc cursus nunc, sed viverra metus lorem vitae nisi.</p>
-          <attrib>Ecclesiastes 10:1</attrib>
+          <!-- <attrib> element is optional. An empty <attrib> element for editing will be created automatically -->
         </disp-quote>
         <p>Morbi malesuada urna nibh, a blandit felis tempus id. Suspendisse libero risus, sagittis sit amet faucibus quis, eleifend eu orci. Etiam ac suscipit ante. In ut odio est. Morbi nisl ex, tincidunt sit amet lorem eget, gravida mattis nunc. Fusce sed quam et felis rhoncus convallis at nec urna. Vestibulum ultricies volutpat odio. Aenean facilisis diam nec neque accumsan, eu faucibus est efficitur <xref ref-type="table" rid="table1"/>. </p>
-
         <table-wrap id="table1">
           <caption>
             <title>Patient Care at End of Follow Up</title>

--- a/src/article/JATS4R.rng
+++ b/src/article/JATS4R.rng
@@ -241,6 +241,18 @@
 
   <!--
     Changes:
+      - Only allow para-level elements followed by an optional <attrib> element
+  -->
+  <define name="disp-quote">
+    <element name="disp-quote">
+      <ref name="disp-quote-attlist"/><!-- use original attributes -->
+      <zeroOrMore><ref name="para-level"/></zeroOrMore>
+      <optional><ref name="attrib"/></optional>
+    </element>
+  </define>
+
+  <!--
+    Changes:
       - Removed phrase and inline elements
 
     TODO: provide transformation

--- a/src/article/TextureJATS.rng
+++ b/src/article/TextureJATS.rng
@@ -674,24 +674,20 @@
   </define>
 
   <!--
-    Pure container for content of <disp-quote>
-
-    TODO: transform
+    Wraps content in explicit <disp-quote-content> container
   -->
   <define name="disp-quote">
     <element name="disp-quote">
       <ref name="disp-quote-attlist"/>
       <ref name="disp-quote-content"/>
-      <zeroOrMore>
-        <ref name="attrib"/>
-      </zeroOrMore>
+      <ref name="attrib"/>
     </element>
   </define>
 
   <define name="disp-quote-content">
     <element name="disp-quote-content">
       <oneOrMore>
-        <ref name="just-para.class"/>
+        <ref name="para-level"/>
       </oneOrMore>
     </element>
   </define>

--- a/src/converter/r2t/WrapDispQuoteContent.js
+++ b/src/converter/r2t/WrapDispQuoteContent.js
@@ -5,8 +5,10 @@ export default class WrapDispQuoteContent {
   import(dom) {
     dom.findAll('disp-quote').forEach((dispQuote) => {
       let attrib = dispQuote.find('attrib')
-      if (!attrib) {
-        // attrib element is required in TextureJATS.
+      // Pull off <attrib> element or create empty element
+      if (attrib) {
+        dispQuote.removeChild(attrib)
+      } else {
         attrib = dom.createElement('attrib')
       }
       let content = dom.createElement('disp-quote-content').append(dispQuote.children)

--- a/src/converter/r2t/WrapDispQuoteContent.js
+++ b/src/converter/r2t/WrapDispQuoteContent.js
@@ -4,14 +4,26 @@ export default class WrapDispQuoteContent {
 
   import(dom) {
     dom.findAll('disp-quote').forEach((dispQuote) => {
-      let attribs = dispQuote.findAll('attrib')
+      let attrib = dispQuote.find('attrib')
+      if (!attrib) {
+        // attrib element is required in TextureJATS.
+        attrib = dom.createElement('attrib')
+      }
       let content = dom.createElement('disp-quote-content').append(dispQuote.children)
       dispQuote.append(content)
-      dispQuote.append(attribs)
+      dispQuote.append(attrib)
     })
   }
 
   export(dom) {
     dom.findAll('disp-quote-content').forEach(unwrapChildren)
+    let dispQuotes = dom.findAll('disp-quote')
+    // Remove all empty attrib elements
+    dispQuotes.forEach((dispQuote) => {
+      let attrib = dispQuote.find('attrib')
+      if (attrib.textContent === '') {
+        dispQuote.removeChild(attrib)
+      }
+    })
   }
 }

--- a/src/editor/styles/_disp-quote.css
+++ b/src/editor/styles/_disp-quote.css
@@ -1,12 +1,15 @@
 .sc-disp-quote {
+  border: 1px solid #ddd;
+  font-size: 20px;
+  padding-left: 20px;
   padding: 10px;
 }
 
 .sc-disp-quote .sc-disp-quote-content {
-  border-left: 2px solid var(--default-text-color);
-  padding-left: 20px;
+
 }
 
 .sc-disp-quote .se-attribution {
   text-align: right;
+  font-size: 16px;
 }


### PR DESCRIPTION
Add strict schema for <disp-quote>. This examples illustrates some patters we use in Texture:

1) We define a strict schema in `JATS4R.rng` (we only allow para-level elements and an optional attrib element)
2) We define an optimized schema in `TextureJATS.rng` (this is the schema that the editor uses internally; to make our life easier we explicitly wrap the contents in a separate `<disp-quote-content>` and make the `<attrib>` non-optional, so our view can always render a placeholder
3) In `WrapDispQuoteContent.js` we perform the transformations needed from JATS4R to TextureJATS: wrap the content in a separate element, and create an empty `<attrib>` element if needed. On export we unwrap the content again and remove empty `<attrib>` elements.

We use that same pattern in many areas. For instance we expand `<element-citation>` elements to have all fields (creating empty elements when needed). For example you can fill out the optional `<issue>` field... on export (=saving) we drop empty fields again. This way the user interface can be kept simple (placeholders for stuff that is not yet there instead of add+remove buttons everywhere).