### PR TITLE
Tx fixes

### DIFF
--- a/src/editor/components/EditXrefTool.js
+++ b/src/editor/components/EditXrefTool.js
@@ -79,8 +79,8 @@ export default class EditXRefTool extends Tool {
     // Flip the selected flag
     target.selected = !target.selected
 
-    editorSession.transaction(function(doc) {
-      let xref = doc.get(node.id)
+    editorSession.transaction(tx => {
+      let xref = tx.get(node.id)
       xref.setAttribute('rid', newTargets.join(' '))
     })
 

--- a/src/editor/components/TranslationsComponent.js
+++ b/src/editor/components/TranslationsComponent.js
@@ -143,21 +143,21 @@ export default class TranslationsComponent extends NodeComponent {
 
   _addTitleTranslation() {
     const editorSession = this.context.editorSession
-    editorSession.transaction((doc) => {
-      let titleGroup = doc.find('article-meta > title-group')
-      let transTitleGroup = doc.createElement('trans-title-group')
-      transTitleGroup.append(doc.createElement('trans-title'))
+    editorSession.transaction(tx => {
+      let titleGroup = tx.find('article-meta > title-group')
+      let transTitleGroup = tx.createElement('trans-title-group')
+      transTitleGroup.append(tx.createElement('trans-title'))
       titleGroup.append(transTitleGroup)
     })
   }
 
   _addAbstractTranslation() {
     const editorSession = this.context.editorSession
-    editorSession.transaction((doc) => {
-      let articleMeta = doc.get(this.props.node.id)
-      let transAbstract = doc.createElement('trans-abstract')
-      let content = doc.createElement('abstract-content')
-      let placeholder = doc.createElement('p')
+    editorSession.transaction(tx => {
+      let articleMeta = tx.get(this.props.node.id)
+      let transAbstract = tx.createElement('trans-abstract')
+      let content = tx.createElement('abstract-content')
+      let placeholder = tx.createElement('p')
       content.append(placeholder)
       transAbstract.append(content)
       articleMeta.append(transAbstract)
@@ -166,16 +166,16 @@ export default class TranslationsComponent extends NodeComponent {
 
   _removeTitleTranslation(nodeId) {
     const editorSession = this.context.editorSession
-    editorSession.transaction((doc) => {
-      let title = doc.get(nodeId)
+    editorSession.transaction(tx => {
+      let title = tx.get(nodeId)
       title.parentNode.removeChild(title)
     })
   }
 
   _removeAbstractTranslation(nodeId) {
     const editorSession = this.context.editorSession
-    editorSession.transaction((doc) => {
-      let transAbstract = doc.get(nodeId)
+    editorSession.transaction(tx => {
+      let transAbstract = tx.get(nodeId)
       transAbstract.parentNode.removeChild(transAbstract)
     })
   }


### PR DESCRIPTION
Why: To avoid confuses related to transactions 
What: We don't want to use doc inside transaction, we don't want to use doc as name for transaction argument as it will produce missunderstanding
