### PR TITLE
Added email attribute to contrib.

### DIFF
--- a/src/article/JATS4R.rng
+++ b/src/article/JATS4R.rng
@@ -242,6 +242,7 @@
         <!-- TODO: contrib-id[contrib-id-type=orcid]?, contrib-id[contrib-id-type=entity]? -->
         <zeroOrMore><ref name="contrib-id"/></zeroOrMore>
         <optional><ref name="name"/></optional>
+        <optional><ref name="email"/></optional>
         <optional><ref name="collab"/></optional>
         <zeroOrMore><ref name="xref"/></zeroOrMore>
       </interleave>

--- a/src/converter/r2t/EntityConverters.js
+++ b/src/converter/r2t/EntityConverters.js
@@ -70,6 +70,7 @@ export const PersonConverter = {
         type: 'person',
         givenNames: _getText(el, 'given-names'),
         surname: _getText(el, 'surname'),
+        email: _getText(el, 'email'),
         prefix: _getText(el, 'prefix'),
         suffix: _getText(el, 'suffix'),
         affiliations: []
@@ -102,6 +103,7 @@ export const PersonConverter = {
       $$('name').append(
         _createTextElement($$, node.surname, 'surname'),
         _createTextElement($$, node.givenNames, 'given-names'),
+        _createTextElement($$, node.email, 'email'),
         _createTextElement($$, node.prefix, 'prefix'),
         _createTextElement($$, node.suffix, 'suffix')
       )
@@ -136,6 +138,7 @@ export const RefPersonConverter = {
         type: 'person',
         givenNames: _getText(el, 'given-names'),
         surname: _getText(el, 'surname'),
+        email: _getText(el, 'email'),
         prefix: _getText(el, 'prefix'),
         suffix: _getText(el, 'suffix'),
       }
@@ -148,6 +151,7 @@ export const RefPersonConverter = {
     let el = $$('name')
     el.append(_createTextElement($$, node.surname, 'surname'))
     el.append(_createTextElement($$, node.givenNames, 'given-names'))
+    el.append(_createTextElement($$, node.email, 'email'))
     el.append(_createTextElement($$, node.prefix, 'prefix'))
     el.append(_createTextElement($$, node.suffix, 'suffix'))
     return el

--- a/src/entities/EntityDatabase.js
+++ b/src/entities/EntityDatabase.js
@@ -211,6 +211,7 @@ Person.schema = {
   type: 'person',
   orcid: { type: 'string', optional: true },
   givenNames: { type: 'string', optional: true },
+  email: { type: 'string', optional: true },
   surname: { type: 'string', optional: true },
   prefix: { type: 'string', optional: true },
   suffix: { type: 'string', optional: true },


### PR DESCRIPTION
Email attribute is currently missing inside contrib element.
This PR adds email to JATS4M schema, person entity schema and entity converters.
