### PR TITLE
Disable xref insertion if nothing can be referenced.

### DIFF
--- a/src/editor/EditorPackage.js
+++ b/src/editor/EditorPackage.js
@@ -400,7 +400,7 @@ export default {
       {
         name: 'cite',
         type: 'tool-dropdown',
-        showDisabled: true,
+        showDisabled: false,
         style: 'descriptive',
         commandGroups: ['insert-xref']
       },

--- a/src/editor/commands/InsertXrefCommand.js
+++ b/src/editor/commands/InsertXrefCommand.js
@@ -1,4 +1,5 @@
 import InsertInlineNodeCommand from './InsertInlineNodeCommand'
+import { hasAvailableXrefTargets } from '../util/xrefHelpers'
 
 export default class InsertXrefCommand extends InsertInlineNodeCommand {
 
@@ -7,10 +8,35 @@ export default class InsertXrefCommand extends InsertInlineNodeCommand {
   }
 
   createNode(tx) {
-    let refType = this.config.refType
+    const refType = this.config.refType
     let xref = tx.createElement('xref')
     xref.attr('ref-type', refType)
     xref.attr('rid', '')
     return xref
+  }
+
+  isDisabled(params) {
+    const sel = params.selection
+    const selectionState = params.editorSession.getSelectionState()
+    const editor = params.editorSession.getEditor()
+    const context = editor.getChildContext()
+    const refType = this.config.refType
+    const hasTargets = hasAvailableXrefTargets(refType, context)
+
+    // We don't allow xref insertion if there are no available targets
+    if (!hasTargets) {
+      return true
+    }
+
+    if (!sel.isPropertySelection()) {
+      return true
+    }
+
+    // We don't allow inserting an inline node on top of an existing inline
+    // node.
+    if (selectionState.isInlineNodeSelection()) {
+      return true
+    }
+    return false
   }
 }

--- a/src/editor/util/xrefHelpers.js
+++ b/src/editor/util/xrefHelpers.js
@@ -55,6 +55,17 @@ function getXrefResourceManager(xref, context) {
   }
 }
 
+export function hasAvailableXrefTargets(refType, context) {
+  let managerName = RefTypeToManager[refType]
+  if (managerName) {
+    const manager = context[managerName]
+    const nodes = manager.getAvailableResources()
+    return nodes.length > 0
+  }
+
+  return false
+}
+
 /*
   Computes available targets for a given xref node
   that the user can choose from.


### PR DESCRIPTION
As described in #415 we don't want to allow href insertions if there are no available targets. This PR adds util function to detect if there are available targets for a certain ref type and overrides isDisabled method of InsertXrefCommand.