### PR TITLE
Supress global dnd events on app level

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -40,6 +40,8 @@ class App extends Component {
     })
     DefaultDOMElement.getBrowserWindow().on('keydown', this._keyDown, this)
     DefaultDOMElement.getBrowserWindow().on('click', this._click, this)
+    DefaultDOMElement.getBrowserWindow().on('drop', this._supressDnD, this)
+    DefaultDOMElement.getBrowserWindow().on('dragover', this._supressDnD, this)
   }
 
   dispose() {
@@ -168,5 +170,12 @@ class App extends Component {
       event.preventDefault();
       shell.openExternal(event.target.href)
     }
+  }
+
+  /*
+    Prevent app and browser from loading a dnd file
+  */
+  _supressDnD(event) {
+    event.preventDefault()
   }
 }

--- a/app/editor.js
+++ b/app/editor.js
@@ -18,6 +18,8 @@ class MyTextureEditor extends Component {
   didMount() {
     this._init()
     DefaultDOMElement.getBrowserWindow().on('keydown', this._keyDown, this)
+    DefaultDOMElement.getBrowserWindow().on('drop', this._supressDnD, this)
+    DefaultDOMElement.getBrowserWindow().on('dragover', this._supressDnD, this)
   }
 
   dispose() {
@@ -114,5 +116,12 @@ class MyTextureEditor extends Component {
         }
       }
     }
+  }
+
+  /*
+    Prevent app and browser from loading a dnd file
+  */
+  _supressDnD(event) {
+    event.preventDefault()
   }
 }

--- a/src/editor/components/Editor.js
+++ b/src/editor/components/Editor.js
@@ -19,6 +19,8 @@ export default class Editor extends AbstractWriter {
     this.editorSession.commandManager._updateCommandStates(this.editorSession)
 
     DefaultDOMElement.getBrowserWindow().on('resize', this._showHideTOC, this)
+    DefaultDOMElement.getBrowserWindow().on('drop', this._supressDnD, this)
+    DefaultDOMElement.getBrowserWindow().on('dragover', this._supressDnD, this)
     this.tocProvider.on('toc:updated', this._showHideTOC, this)
     this._showHideTOC()
   }
@@ -216,4 +218,10 @@ export default class Editor extends AbstractWriter {
     return bodyContent.id
   }
 
+  /*
+    Prevent app and browser from loading a dnd file
+  */
+  _supressDnD(e) {
+    e.preventDefault()
+  }
 }

--- a/src/editor/components/Editor.js
+++ b/src/editor/components/Editor.js
@@ -19,8 +19,6 @@ export default class Editor extends AbstractWriter {
     this.editorSession.commandManager._updateCommandStates(this.editorSession)
 
     DefaultDOMElement.getBrowserWindow().on('resize', this._showHideTOC, this)
-    DefaultDOMElement.getBrowserWindow().on('drop', this._supressDnD, this)
-    DefaultDOMElement.getBrowserWindow().on('dragover', this._supressDnD, this)
     this.tocProvider.on('toc:updated', this._showHideTOC, this)
     this._showHideTOC()
   }
@@ -216,12 +214,5 @@ export default class Editor extends AbstractWriter {
     const doc = this.editorSession.getDocument()
     let bodyContent = doc.article.find('body-content')
     return bodyContent.id
-  }
-
-  /*
-    Prevent app and browser from loading a dnd file
-  */
-  _supressDnD(e) {
-    e.preventDefault()
   }
 }


### PR DESCRIPTION
As described in #427 we have a problems when a file is dropped outside the dropzone. In Desktop app it replaces a web-view, in browser it will open a local file. 
To fix that we should supress dnd events on app level. This PR do exactly that for a browser and desktop versions.
