### PR TITLE
Recompute labels based on documents changes.

### DIFF
--- a/src/editor/components/FnGroupComponent.js
+++ b/src/editor/components/FnGroupComponent.js
@@ -70,7 +70,6 @@ export default class FnGroupComponent extends NodeComponent {
   */
   _addFn() {
     const editorSession = this.context.editorSession
-    const footnoteManager = this.context.footnoteManager
     editorSession.transaction((tx) => {
       let fnGroup = tx.find('fn-group')
       let fn = tx.createElement('fn')
@@ -79,17 +78,14 @@ export default class FnGroupComponent extends NodeComponent {
       fnGroup.append(fn)
       tx.setSelection(null)
     })
-    footnoteManager._updateLabels()
     this.rerender()
   }
 
   _removeFn(fnId) {
     let editorSession = this.context.editorSession
-    const footnoteManager = this.context.footnoteManager
     const doc = editorSession.getDocument()
     const parent = doc.find('fn-group')
     removeElementAndXrefs(editorSession, fnId, parent)
-    footnoteManager._updateLabels()
     this.rerender()
   }
 }

--- a/src/editor/components/RefListComponent.js
+++ b/src/editor/components/RefListComponent.js
@@ -132,14 +132,12 @@ export default class RefListComponent extends NodeComponent {
 
   _onAddNew(entityId) {
     const editorSession = this.context.editorSession
-    const referenceManager = this.context.referenceManager
     editorSession.transaction(tx => {
       let refList = tx.find('ref-list')
       let entityRefNode = tx.createElement('ref')
       entityRefNode.setAttribute('rid', entityId)
       refList.appendChild(entityRefNode)
     })
-    referenceManager._updateLabels()
     this.setState({
       popup: false
     })
@@ -147,12 +145,10 @@ export default class RefListComponent extends NodeComponent {
 
   _onRemove(entityId) {
     let editorSession = this.context.editorSession
-    const referenceManager = this.context.referenceManager
     const doc = editorSession.getDocument()
     const parent = doc.find('ref-list')
     let refId = this._getRefIdForEntityId(entityId)
     removeElementAndXrefs(editorSession, refId, parent)
-    referenceManager._updateLabels()
   }
 
   _onCreate(targetType) {

--- a/src/editor/util/AbstractCitationManager.js
+++ b/src/editor/util/AbstractCitationManager.js
@@ -37,6 +37,9 @@ export default class AbstractCitationManager {
           if (op.val.type === 'xref' && op.val.attributes && op.val.attributes['ref-type'] === this.type) {
             needsUpdate = true
           }
+          if (op.val.type === 'ref' && op.val.attributes) {
+            needsUpdate = true
+          }
           break
         }
         case 'set': {

--- a/src/editor/util/AbstractCitationManager.js
+++ b/src/editor/util/AbstractCitationManager.js
@@ -40,6 +40,9 @@ export default class AbstractCitationManager {
           if (op.val.type === 'ref' && op.val.attributes) {
             needsUpdate = true
           }
+          if (op.val.type === 'fn') {
+            needsUpdate = true
+          }
           break
         }
         case 'set': {


### PR DESCRIPTION
Why: We detected some problems with labels computation on undo/redo (#393).
What: We are no longer trigger label recomputation from components, but looking more carefully through documents changes for certain operations inside Abstract Citation Manager. 
