### PR TITLE
Revert back single formatting command group

### DIFF
--- a/src/editor/EditorPackage.js
+++ b/src/editor/EditorPackage.js
@@ -307,7 +307,7 @@ export default {
     config.addAnnotationTool({
       name: 'bold',
       nodeType: 'bold',
-      commandGroup: 'formatting-primary',
+      commandGroup: 'formatting',
       icon: 'fa-bold',
       label: 'Strong',
       accelerator: 'CommandOrControl+B'
@@ -316,7 +316,7 @@ export default {
     config.addAnnotationTool({
       name: 'italic',
       nodeType: 'italic',
-      commandGroup: 'formatting-primary',
+      commandGroup: 'formatting',
       icon: 'fa-italic',
       label: 'Emphasize',
       accelerator: 'CommandOrControl+I'
@@ -433,7 +433,7 @@ export default {
         type: 'tool-group',
         showDisabled: true,
         style: 'minimal',
-        commandGroups: ['formatting-primary', 'formatting']
+        commandGroups: ['formatting']
       },
       {
         name: 'additinal-tools',


### PR DESCRIPTION
Why: We did introduced new command group formatting-primary in #439 which turns to be a problem for stencila.
What: This is just a reversion to the old formatting command group.
