### PR TITLE
Fix deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - "6"
+  - "8"
 before_script:
     - 'npm install'
 script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3905,7 +3905,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },

--- a/src/converter/r2t/UpdateDocType.js
+++ b/src/converter/r2t/UpdateDocType.js
@@ -3,13 +3,13 @@ import { TextureArticle, DarArticle } from '../../article'
 export default class UpdateDocType {
 
   import(dom) {
-    dom.setDocType(
+    dom.setDoctype(
       ...TextureArticle.getDocTypeParams()
     )
   }
 
   export(dom) {
-    dom.setDocType(
+    dom.setDoctype(
       ...DarArticle.getDocTypeParams()
     )
   }


### PR DESCRIPTION
Fixes a deprecation warning by using `dom.setDoctype()` instead of  'dom.setDocType()' 