### PR TITLE
Collapse selection after ext-link insertion

### DIFF
--- a/src/editor/EditorPackage.js
+++ b/src/editor/EditorPackage.js
@@ -56,6 +56,7 @@ import TableFigPreview from './components/TableFigPreview'
 
 import DecreaseHeadingLevelCommand from './commands/DecreaseHeadingLevelCommand'
 import IncreaseHeadingLevelCommand from './commands/IncreaseHeadingLevelCommand'
+import InsertExtLinkCommand from './commands/InsertExtLinkCommand'
 import InsertDispQuoteCommand from './commands/InsertDispQuoteCommand'
 import InsertXrefCommand from './commands/InsertXrefCommand'
 import ToggleContentSection from './commands/ToggleContentSection'
@@ -322,6 +323,14 @@ export default {
       accelerator: 'CommandOrControl+I'
     })
 
+    config.addCommand('ext-link', InsertExtLinkCommand, {
+      nodeType: 'ext-link',
+      commandGroup: 'formatting',
+    })
+    config.addIcon('ext-link', { 'fontawesome': 'fa-link' })
+    config.addLabel('ext-link', 'Link')
+    config.addKeyboardShortcut('CommandOrControl+K', { command: 'ext-link' })
+
     config.addAnnotationTool({
       name: 'sub',
       nodeType: 'sub',
@@ -344,15 +353,6 @@ export default {
       commandGroup: 'formatting',
       icon: 'fa-code',
       label: 'Monospace'
-    })
-
-    config.addAnnotationTool({
-      name: 'ext-link',
-      nodeType: 'ext-link',
-      commandGroup: 'formatting',
-      icon: 'fa-link',
-      label: 'Link',
-      accelerator: 'CommandOrControl+K'
     })
 
     config.addTextTypeTool({

--- a/src/editor/EditorPackage.js
+++ b/src/editor/EditorPackage.js
@@ -323,13 +323,15 @@ export default {
       accelerator: 'CommandOrControl+I'
     })
 
-    config.addCommand('ext-link', InsertExtLinkCommand, {
+    config.addAnnotationTool({
+      name: 'ext-link',
       nodeType: 'ext-link',
       commandGroup: 'formatting',
+      command: InsertExtLinkCommand,
+      icon: 'fa-link',
+      label: 'Link',
+      accelerator: 'CommandOrControl+K'
     })
-    config.addIcon('ext-link', { 'fontawesome': 'fa-link' })
-    config.addLabel('ext-link', 'Link')
-    config.addKeyboardShortcut('CommandOrControl+K', { command: 'ext-link' })
 
     config.addAnnotationTool({
       name: 'sub',

--- a/src/editor/commands/InsertExtLinkCommand.js
+++ b/src/editor/commands/InsertExtLinkCommand.js
@@ -1,0 +1,14 @@
+import { AnnotationCommand } from 'substance'
+
+class InsertExtLinkCommand extends AnnotationCommand {
+  executeCreate(params) {
+    let result = super.executeCreate(params)
+    let editorSession = this._getEditorSession(params)
+    editorSession.transaction((tx) => {
+      tx.setSelection(tx.selection.collapse())
+    })
+    return result
+  }
+}
+
+export default InsertExtLinkCommand

--- a/src/editor/util/TextureConfigurator.js
+++ b/src/editor/util/TextureConfigurator.js
@@ -4,7 +4,8 @@ import NumberedLabelGenerator from './NumberedLabelGenerator'
 export default class TextureConfigurator extends Configurator {
 
   addAnnotationTool(spec) {
-    this.addCommand(spec.name, AnnotationCommand, {
+    let Command = spec.command || AnnotationCommand
+    this.addCommand(spec.name, Command, {
       nodeType: spec.nodeType,
       commandGroup: spec.commandGroup,
     })
@@ -25,7 +26,6 @@ export default class TextureConfigurator extends Configurator {
     if (spec.accelerator) {
       this.addKeyboardShortcut(spec.accelerator, { command: spec.name })
     }
-
   }
 
   setPanelsSpec(panelsSpec) {


### PR DESCRIPTION
Why: At the moment edit prompt isn't showing after ext-link insertion, so an extra click needed.
What: This PR contains new command and config.

@michael pls review, I had to insert new config (comand, icon, label, keyboard shortcut) in the middle of annotation tools definition. It's not very beautiful, but I can't see other ways to save an old position of the tool. 
I think that the more elegant way could be to add `spec.command` and set `AnnotationCommand` as a default to addAnnotationTool. What do you think? Than we will still be able to call config.addAnnotationTool