### PR TITLE
Make Dar robust against missing files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3627,12 +3627,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
       "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
-    "lodash-es": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.13.1.tgz",
-      "integrity": "sha1-Pao28j8J7eCSpviIM//eCPe4WTw=",
-      "dev": true
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -4750,17 +4744,25 @@
       "dev": true
     },
     "substance": {
-      "version": "1.0.0-preview.42",
-      "resolved": "https://registry.npmjs.org/substance/-/substance-1.0.0-preview.42.tgz",
-      "integrity": "sha512-M7d3tomEIOS6r4bNcs8mL6BxZ0vC/aQMH45aDwxgoO6zxDevmE46diJLstYjjqdnLb3pd9ksJYSsEvJ/cftWqQ==",
+      "version": "1.0.0-preview.44",
+      "resolved": "https://registry.npmjs.org/substance/-/substance-1.0.0-preview.44.tgz",
+      "integrity": "sha512-UuFyjpChOdJeqO1cOrNlP1R5pF+MjwccjpLNW5OdykMfuqb2pRG1Gs6+e1uuoEHpt0iVasAAmyNlqfeuUildhQ==",
       "dev": true,
       "requires": {
         "boolbase": "1.0.0",
         "css-what": "2.1.0",
         "domelementtype": "1.3.0",
         "entities": "1.1.1",
-        "lodash-es": "4.13.1",
+        "lodash-es": "4.17.10",
         "nth-check": "1.0.1"
+      },
+      "dependencies": {
+        "lodash-es": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+          "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
+          "dev": true
+        }
       }
     },
     "substance-bundler": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lodash": "^4.14.1"
   },
   "peerDependency": {
-    "substance": ">=1.0.0-preview.42"
+    "substance": ">=1.0.0-preview.44"
   },
   "devDependencies": {
     "dar-server": "^0.4.1",
@@ -21,7 +21,7 @@
     "source-map-support": "0.5.3",
     "substance-bundler": "0.21.2",
     "substance-test": "^0.9.4",
-    "substance": "1.0.0-preview.42"
+    "substance": "1.0.0-preview.44"
   },
   "scripts": {
     "prepare": "node make publish",

--- a/src/TextureArchive.js
+++ b/src/TextureArchive.js
@@ -22,6 +22,9 @@ export default class TextureArchive extends PersistedDocumentArchive {
 
     entries.forEach(entry => {
       let record = rawArchive.resources[entry.path]
+      // Note: this happens when a resource is referenced in the manifest
+      // but is not there actually
+      // we skip loading here and will fix the manuscript later on
       if (!record) {
         return
       }

--- a/src/TextureArchive.js
+++ b/src/TextureArchive.js
@@ -21,6 +21,7 @@ export default class TextureArchive extends PersistedDocumentArchive {
     sessions['pub-meta'] = pubMetaSession
 
     entries.forEach(entry => {
+      let record = rawArchive.resources[entry.path]
       // Load any document except pub-meta (which we prepared manually)
       if (entry.type !== 'pub-meta') {
         // Passing down 'sessions' so that we can add to the pub-meta session

--- a/src/TextureArchive.js
+++ b/src/TextureArchive.js
@@ -22,6 +22,10 @@ export default class TextureArchive extends PersistedDocumentArchive {
 
     entries.forEach(entry => {
       let record = rawArchive.resources[entry.path]
+      if (!record) {
+        console.warn(`${entry.path} could not be found. Skipping...`)
+        return
+      }
       // Load any document except pub-meta (which we prepared manually)
       if (entry.type !== 'pub-meta') {
         // Passing down 'sessions' so that we can add to the pub-meta session


### PR DESCRIPTION
Why: A common source of the error was that StencilaArchive/TextureArchive crashed because of a missing sheet.xml
What: Make sure, that a DAR can still be opened, and a warning is printed.