### PR TITLE
Toggle xref targets via models.

### DIFF
--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -266,6 +266,27 @@ export default class ArticleAPI extends AbstractAPI {
     })
   }
 
+  addXrefTarget (targetId, model) {
+    const articleSession = this.articleSession
+    articleSession.transaction(tx => {
+      const xref = tx.get(model.id)
+      let targets = xref.getAttribute('rid').split(' ')
+      targets.push(targetId)
+      xref.setAttribute('rid', targets.join(' '))
+    })
+  }
+
+  removeXrefTarget (targetId, model) {
+    const articleSession = this.articleSession
+    articleSession.transaction(tx => {
+      const xref = tx.get(model.id)
+      let targets = xref.getAttribute('rid').split(' ')
+      let idx = targets.indexOf(targetId)
+      targets.splice(idx, 1)
+      xref.setAttribute('rid', targets.join(' '))
+    })
+  }
+
   _getContext () {
     return this._context
   }

--- a/src/article/editor/EditXrefTool.js
+++ b/src/article/editor/EditXrefTool.js
@@ -44,43 +44,17 @@ export default class EditXRefTool extends ToggleTool {
     return model.getAvailableTargets()
   }
 
-  _toggleTarget (targetNodeId, e) { // eslint-disable-line
-    // TODO: implement this in a model idiomatic way
-    console.error('TODO: implement EditXRefTool._toggleTarget()')
-
+  _toggleTarget (targetNodeId, e) {
     // // Make sure we don't follow external links
-    // e.preventDefault()
-    // e.stopPropagation()
+    e.preventDefault()
+    e.stopPropagation()
 
-    // let node = this._getNode(this.props.commandState.nodeId)
-    // let editorSession = this.context.editorSession
-    // // console.log('XRefTargets: toggling target of ', node.id);
+    const model = this._getModel()
+    const targets = model.toggleTarget(targetNodeId)
 
-    // // Update model
-    // let newTargets = getXrefTargets(node)
-    // if (newTargets.indexOf(targetNodeId) >= 0) {
-    //   newTargets = without(newTargets, targetNodeId)
-    // } else {
-    //   newTargets.push(targetNodeId)
-    // }
-
-    // // Compute visual feedback
-    // let targets = this.state.targets;
-    // let target = find(this.state.targets, function(t) {
-    //   return t.id === targetNodeId
-    // })
-
-    // // Flip the selected flag
-    // target.selected = !target.selected
-
-    // editorSession.transaction(tx => {
-    //   let xref = tx.get(node.id)
-    //   xref.setAttribute('rid', newTargets.join(' '))
-    // })
-
-    // // Triggers a rerender
-    // this.setState({
-    //   targets: targets
-    // })
+    // Triggers a rerender
+    this.setState({
+      targets: targets
+    })
   }
 }

--- a/src/article/models/XrefModel.js
+++ b/src/article/models/XrefModel.js
@@ -8,6 +8,10 @@ export default class XrefModel {
     this._node = node
   }
 
+  get id () {
+    return this._node.id
+  }
+
   getTargets () {
     let targetIds = getXrefTargets(this._node)
     return targetIds.map(id => this._api.getModelById(id))
@@ -20,5 +24,16 @@ export default class XrefModel {
       entry.model = this._api.getModelById(entry.id)
       return entry
     })
+  }
+
+  toggleTarget (nodeId) {
+    let targetIds = getXrefTargets(this._node)
+    let idx = targetIds.indexOf(nodeId)
+    if (idx > -1) {
+      this._api.removeXrefTarget(nodeId, this)
+    } else {
+      this._api.addXrefTarget(nodeId, this)
+    }
+    return this.getAvailableTargets()
   }
 }


### PR DESCRIPTION
With switching to the model-driven approach we want to ask models to change xref targets and perform transactions in the Article API.