### PR TITLE
Fix Figure Deletion 

### DIFF
--- a/src/kit/app/EditorSessionMixin.js
+++ b/src/kit/app/EditorSessionMixin.js
@@ -174,18 +174,34 @@ export default function (DocumentSession) {
     }
 
     onPostRender (...args) {
-      console.error('DEPRECATED: use EditorState API')
+      if (_shouldDisplayDeprecatedWarning()) {
+        console.error('DEPRECATED: use EditorState API')
+      }
       return this._registerObserver('post-render', args)
     }
 
     onPosition (...args) {
-      console.error('DEPRECATED: use EditorState API')
+      if (_shouldDisplayDeprecatedWarning()) {
+        console.error('DEPRECATED: use EditorState API')
+      }
       return this._registerObserver('position', args)
     }
 
     onFinalize (...args) {
-      console.error('DEPRECATED: use EditorState API')
+      if (_shouldDisplayDeprecatedWarning()) {
+        console.error('DEPRECATED: use EditorState API')
+      }
       return this._registerObserver('finalize', args)
+    }
+
+    // ATTENTION: while we want to get rid of the former event registration
+    // we still need this to avoid breaking legacy code
+    off (...args) {
+      if (args.length === 1) {
+        let observer = args[0]
+        this.editorState.removeObserver(observer)
+      }
+      super.off(...args)
     }
 
     _onDocumentChange (change, info) {


### PR DESCRIPTION
## Why

see #709 

## What

This brings back legacy support in the new EditorSession implementation, necessary for some implementation in Substance core to work correctly.
