### PR TITLE
Revert keyboard shortcuts in toolbar

### DIFF
--- a/src/article/ArticleConfigurator.js
+++ b/src/article/ArticleConfigurator.js
@@ -1,4 +1,4 @@
-import { AnnotationCommand, SwitchTextTypeCommand } from 'substance'
+import { AnnotationCommand, platform, SwitchTextTypeCommand } from 'substance'
 import TextureConfigurator from '../TextureConfigurator'
 import NumberedLabelGenerator from './shared/NumberedLabelGenerator'
 import InternalArticleSchema from './InternalArticleSchema'
@@ -62,5 +62,35 @@ export default class ArticleConfigurator extends TextureConfigurator {
       config = this.config.labelGenerator[type] || {}
     }
     return new NumberedLabelGenerator(config)
+  }
+
+  getKeyboardShortcuts () {
+    return this.config.keyboardShortcuts
+  }
+
+  /*
+    Allows lookup of a keyboard shortcut by command name
+  */
+  getKeyboardShortcutsByCommandName (commandName) {
+    let keyboardShortcuts = {}
+    this.config.keyboardShortcuts.forEach((entry) => {
+      if (entry.spec.command) {
+        let shortcut = entry.key.toUpperCase()
+
+        if (platform.isMac) {
+          shortcut = shortcut.replace(/CommandOrControl/i, '⌘')
+          shortcut = shortcut.replace(/Ctrl/i, '^')
+          shortcut = shortcut.replace(/Shift/i, '⇧')
+          shortcut = shortcut.replace(/Enter/i, '↵')
+          shortcut = shortcut.replace(/Alt/i, '⌥')
+          shortcut = shortcut.replace(/\+/g, '')
+        } else {
+          shortcut = shortcut.replace(/CommandOrControl/i, 'Ctrl')
+        }
+
+        keyboardShortcuts[entry.spec.command] = shortcut
+      }
+    })
+    return keyboardShortcuts[commandName]
   }
 }

--- a/src/article/styles/_article-panel.css
+++ b/src/article/styles/_article-panel.css
@@ -44,3 +44,7 @@
   background: inherit;
   color: inherit;
 }
+
+.sc-article-panel .sc-toolbar .sc-menu-item .se-keyboard-shortcut {
+  color: rgba(0, 0, 0, 0.4);
+}

--- a/src/kit/ui/MenuItem.js
+++ b/src/kit/ui/MenuItem.js
@@ -49,8 +49,11 @@ export default class MenuItem extends Component {
   }
 
   _renderKeyboardShortcut ($$) {
+    const name = this.props.commandName
+    const config = this.context.config
+    const keyboardShortcut = config.getKeyboardShortcutsByCommandName(name)
     return $$('div').addClass('se-keyboard-shortcut').append(
-      this.props.keyboardShortcut || ''
+      keyboardShortcut || ''
     )
   }
 

--- a/src/kit/ui/ToggleTool.js
+++ b/src/kit/ui/ToggleTool.js
@@ -54,8 +54,10 @@ export default class ToggleTool extends Component {
 
   _getTooltipText () {
     const label = this._getLabel()
+    const name = this._getName()
     // TODO: instead of letting this tool lookup keyboard shortcutm it should
-    const keyboardShortcut = this.props.keyboardShortcut
+    const config = this.context.config
+    const keyboardShortcut = config.getKeyboardShortcutsByCommandName(name)
     if (keyboardShortcut) {
       return [label, ' (', keyboardShortcut, ')'].join('')
     } else {


### PR DESCRIPTION
## Why

We introduced a regression with pulling Tools and out of substance core, keyboard shortcuts are no longer shown in toolbar.

## What

This PR is an attempt to bring back keyboard shortcuts in toolbar labels. To do it I did introduce a method ```getKeyboardShortcutsByCommandName``` in configurator.