### PR TITLE
WIP: Replicate cell type when inserting a new column and row

### DIFF
--- a/src/article/shared/TableEditing.js
+++ b/src/article/shared/TableEditing.js
@@ -325,9 +325,10 @@ export default class TableEditing {
         let cellBefore = row.getChildAt(colIdx - 1)
         protoAttributes = cellBefore.getAttributes()
       }
+      let isHeading = protoAttributes.heading
       for (let j = 0; j < n; j++) {
         let cell = $$('table-cell')
-        cell.attr(protoAttributes)
+        if (isHeading) cell.attr({heading: true})
         row.insertBefore(cell, cellAfter)
       }
     }

--- a/src/article/shared/TableEditing.js
+++ b/src/article/shared/TableEditing.js
@@ -318,8 +318,16 @@ export default class TableEditing {
     while (rowIt.hasNext()) {
       let row = rowIt.next()
       let cellAfter = row.getChildAt(colIdx)
+      let protoAttributes
+      if (cellAfter) {
+        protoAttributes = cellAfter.getAttributes()
+      } else {
+        let cellBefore = row.getChildAt(colIdx - 1)
+        protoAttributes = cellBefore.getAttributes()
+      }
       for (let j = 0; j < n; j++) {
         let cell = $$('table-cell')
+        cell.attr(protoAttributes)
         row.insertBefore(cell, cellAfter)
       }
     }


### PR DESCRIPTION
When a new column or row added we want to copy some of the cell attributes.
Currently we want to copy only cell heading attribute, but in future we may want to copy cell types as well.
This PR contains changes to TableEditing interface, we are keeping cell attributes from other column, but currently replicate only heading attribute.
