### PR TITLE
Find and replace (Iteration II)

### DIFF
--- a/src/article/editor/ManuscriptEditor.js
+++ b/src/article/editor/ManuscriptEditor.js
@@ -7,9 +7,10 @@ import TOC from './TOC'
 
 export default class ManuscriptEditor extends EditorPanel {
   getActionHandlers () {
-    let handlers = super.getActionHandlers()
-    handlers.tocEntrySelected = this._tocEntrySelected
-    return handlers
+    return Object.assign(super.getActionHandlers(), {
+      tocEntrySelected: this._tocEntrySelected,
+      scrollElementIntoView: this._scrollElementIntoView
+    })
   }
 
   _initialize (props) {
@@ -196,6 +197,7 @@ export default class ManuscriptEditor extends EditorPanel {
       let surface = nodeComponent.context.surface
       // There are cases when we can't set selection, e.g. for references
       if (surface) {
+        // Note: in this case we do not need to scroll explicitly because this will be done by the SurfaceManager
         editorSession.setSelection({
           type: 'property',
           path: node.getPath(),
@@ -203,13 +205,10 @@ export default class ManuscriptEditor extends EditorPanel {
           surfaceId: surface.id,
           containerId: surface.getContainerId()
         })
+      } else {
+        return this._scrollElementIntoView(nodeComponent.el)
       }
-      return this._scrollTo(nodeId)
     }
-  }
-
-  _scrollTo (nodeId) {
-    this.refs.contentPanel.scrollTo(`[data-id="${nodeId}"]`)
   }
 
   _showHideTOC () {
@@ -228,5 +227,9 @@ export default class ManuscriptEditor extends EditorPanel {
 
   _getTOCProvider () {
     return new TOCProvider(this.props.articleSession, { containerId: 'body' })
+  }
+
+  _scrollElementIntoView (el) {
+    this.refs.contentPanel.scrollElementIntoView(el, 'onlyIfNotVisible')
   }
 }

--- a/src/article/editor/ManuscriptEditor.js
+++ b/src/article/editor/ManuscriptEditor.js
@@ -8,8 +8,7 @@ import TOC from './TOC'
 export default class ManuscriptEditor extends EditorPanel {
   getActionHandlers () {
     return Object.assign(super.getActionHandlers(), {
-      tocEntrySelected: this._tocEntrySelected,
-      scrollElementIntoView: this._scrollElementIntoView
+      tocEntrySelected: this._tocEntrySelected
     })
   }
 
@@ -165,6 +164,10 @@ export default class ManuscriptEditor extends EditorPanel {
     }
   }
 
+  _getContentPanel () {
+    return this.refs.contentPanel
+  }
+
   getViewport () {
     return {
       x: this.refs.contentPanel.getScrollPosition()
@@ -191,7 +194,7 @@ export default class ManuscriptEditor extends EditorPanel {
   _tocEntrySelected (nodeId) {
     const node = this._getDocument().get(nodeId)
     const editorSession = this._getEditorSession()
-    const nodeComponent = this.refs.contentPanel.find(`[data-id="${nodeId}"]`)
+    const nodeComponent = this._getContentPanel().find(`[data-id="${nodeId}"]`)
     if (nodeComponent) {
       // TODO: it needs to be easier to retrieve the surface
       let surface = nodeComponent.context.surface
@@ -227,9 +230,5 @@ export default class ManuscriptEditor extends EditorPanel {
 
   _getTOCProvider () {
     return new TOCProvider(this.props.articleSession, { containerId: 'body' })
-  }
-
-  _scrollElementIntoView (el) {
-    this.refs.contentPanel.scrollElementIntoView(el, 'onlyIfNotVisible')
   }
 }

--- a/src/article/metadata/MetadataEditor.js
+++ b/src/article/metadata/MetadataEditor.js
@@ -118,4 +118,8 @@ export default class MetadataEditor extends EditorPanel {
     )
     return el
   }
+
+  _getContentPanel () {
+    return this.refs.contentPanel
+  }
 }

--- a/src/article/shared/EditorPanel.js
+++ b/src/article/shared/EditorPanel.js
@@ -16,7 +16,8 @@ export default class EditorPanel extends Component {
       executeCommand: this._executeCommand,
       toggleOverlay: this._toggleOverlay,
       startWorkflow: this._startWorkflow,
-      closeModal: this._closeModal
+      closeModal: this._closeModal,
+      scrollElementIntoView: this._scrollElementIntoView
     }
   }
 
@@ -94,6 +95,14 @@ export default class EditorPanel extends Component {
     appState.workflowId = null
     appState.overlayId = null
     appState.propagateUpdates()
+  }
+
+  _scrollElementIntoView (el) {
+    this._getContentPanel().scrollElementIntoView(el, 'onlyIfNotVisible')
+  }
+
+  _getContentPanel () {
+    throw new Error('This method is abstract')
   }
 
   _getConfigurator () {

--- a/src/kit/app/FindAndReplaceDialog.js
+++ b/src/kit/app/FindAndReplaceDialog.js
@@ -142,9 +142,8 @@ export default class FindAndReplaceDialog extends Component {
     let state = this._getState()
     let el = $$('span').addClass('se-status')
     if (state.count > 0) {
-      el.append(
-        [String(state.cursor+1), state.count].join(' / ')
-      )
+      let current = state.cursor === -1 ? '?' : String(state.cursor + 1)
+      el.append(`${current} / ${state.count}`)
     } else if (state.pattern) {
       el.append(this.getLabel('no-result'))
     }

--- a/src/kit/app/FindAndReplaceDialog.js
+++ b/src/kit/app/FindAndReplaceDialog.js
@@ -65,13 +65,15 @@ export default class FindAndReplaceDialog extends Component {
         this._renderStatus($$),
         $$(Button, {
           tooltip: this.getLabel('find-next'),
-          theme: this.props.theme
+          theme: this.props.theme,
+          disabled: state.count < 1
         }).addClass('sm-next')
           .append(this.getLabel('next'))
           .on('click', this._findNext),
         $$(Button, {
           tooltip: this.getLabel('find-previous'),
-          theme: this.props.theme
+          theme: this.props.theme,
+          disabled: state.count < 1
         }).addClass('sm-previous')
           .append(this.getLabel('previous'))
           .on('click', this._findPrevious),
@@ -141,7 +143,7 @@ export default class FindAndReplaceDialog extends Component {
     let el = $$('span').addClass('se-status')
     if (state.count > 0) {
       el.append(
-        ['?', state.count].join(' / ')
+        [String(state.cursor+1), state.count].join(' / ')
       )
     } else if (state.pattern) {
       el.append(this.getLabel('no-result'))
@@ -168,11 +170,11 @@ export default class FindAndReplaceDialog extends Component {
   }
 
   _findNext () {
-    console.error('TODO: findNext()')
+    this._getManager().next()
   }
 
   _findPrevious () {
-    console.error('TODO: findPrevious()')
+    this._getManager().previous()
   }
 
   _replaceNext () {

--- a/src/kit/app/FindAndReplaceManager.js
+++ b/src/kit/app/FindAndReplaceManager.js
@@ -14,7 +14,6 @@ export default class FindAndReplaceManager {
     markersManager.on('text-property:changed', this._onTextPropertyChanged, this)
 
     appState.addObserver(['document'], this._onDocumentChange, this, { stage: 'render' })
-    appState.addObserver(['selection'], this._onSelectionChange, this, { stage: 'update' })
 
     this._updateSearch = debounce(this._updateSearch.bind(this), UPDATE_DELAY)
   }
@@ -296,13 +295,6 @@ export default class FindAndReplaceManager {
 
   _onDocumentChange () {
     this._updateSearch()
-  }
-
-  // Note: we keep an internal flag indicating that the next match navigation
-  // should be done relative the current selection rather than relative
-  // to the current match
-  _onSelectionChange () {
-    this._relativeToMatch = false
   }
 
   static defaultState () {

--- a/src/kit/app/FindAndReplaceManager.js
+++ b/src/kit/app/FindAndReplaceManager.js
@@ -1,4 +1,4 @@
-import { debounce } from 'substance'
+import { debounce, uuid } from 'substance'
 
 const UPDATE_DELAY = 200
 
@@ -14,6 +14,7 @@ export default class FindAndReplaceManager {
     markersManager.on('text-property:changed', this._onTextPropertyChanged, this)
 
     appState.addObserver(['document'], this._onDocumentChange, this, { stage: 'render' })
+    appState.addObserver(['selection'], this._onSelectionChange, this, { stage: 'update' })
 
     this._updateSearch = debounce(this._updateSearch.bind(this), UPDATE_DELAY)
   }
@@ -30,10 +31,9 @@ export default class FindAndReplaceManager {
     } else {
       state.enabled = true
       state.showReplace = Boolean(enableReplace)
-      this._searchAndHighlight()
-      this._updateState(state)
       // resetting dirty flags as we do a full search initially
       this._dirty = new Set()
+      this.search()
     }
   }
 
@@ -43,15 +43,43 @@ export default class FindAndReplaceManager {
     state.enabled = false
     this._clearHighlights()
     // Note: recovering the selection here
-    this._updateState(state, true)
+    this._updateState(state, 'recoverSelection')
+  }
+
+  search () {
+    let state = this._getState()
+    if (state.pattern) {
+      this._searchAndHighlight()
+    } else {
+      this._clearHighlights()
+    }
+    state.cursor = -1
+    this._updateState(state)
+    // ATTENTION: scrolling to the first match (if available)
+    // this needs to be done after rolling out the state update
+    // so that the markers have been rendered already
+    if (state.count > 0) {
+      this.next()
+    }
+  }
+
+  next () {
+    let state = this._getState()
+    this._nav('forward')
+    this._updateState(state)
+  }
+
+  previous () {
+    let state = this._getState()
+    this._nav('back')
+    this._updateState(state)
   }
 
   setSearchPattern (pattern) {
     let state = this._getState()
     if (state.pattern !== pattern) {
       state.pattern = pattern
-      this._searchAndHighlight()
-      this._updateState(state)
+      this.search()
     }
   }
 
@@ -82,10 +110,7 @@ export default class FindAndReplaceManager {
   _toggleOption (optionName) {
     let state = this._getState()
     state[optionName] = !state[optionName]
-    if (state.pattern) {
-      this._searchAndHighlight()
-    }
-    this._updateState(state)
+    this.search()
   }
 
   _updateState (state, recoverSelection) {
@@ -151,12 +176,19 @@ export default class FindAndReplaceManager {
     state.count = count
     state.matches = matches
     // HACK: need to make sure that the selection is recovered here
-    this._updateState(state, true)
+    this._updateState(state, 'recoverSelection')
     this._dirty = new Set()
   }
 
   _searchInProperty (tp, pattern, opts) {
-    return _findInText(tp.getText(), pattern, opts)
+    let path = tp.getPath()
+    return _findInText(tp.getText(), pattern, opts).map(m => {
+      // add an id so that we can find it later, e.g. for scroll-to
+      m.id = uuid()
+      m.path = path
+      m.textProperty = tp
+      return m
+    })
   }
 
   _clearHighlights () {
@@ -186,6 +218,7 @@ export default class FindAndReplaceManager {
     matches.forEach(m => {
       markersManager.addPropertyMarker(path, {
         type: 'find-marker',
+        id: m.id,
         start: {
           path,
           offset: m.start
@@ -208,12 +241,68 @@ export default class FindAndReplaceManager {
     return this._markersManager._textProperties.getTextProperty(key)
   }
 
+  _nav (direction) {
+    let state = this._getState()
+    let [cursor, match] = this._getNext(direction)
+    if (match) {
+      state.cursor = cursor
+      this._scrollToMatch(match)
+    }
+  }
+
+  _getNext (direction) {
+    // TODO: support a selection relative navigation
+    // as a first iteration we will do this independently from the selection
+    let state = this._getState()
+    let idx
+    if (direction === 'forward') {
+      idx = Math.min(state.count - 1, state.cursor + 1)
+    } else {
+      idx = Math.max(0, state.cursor - 1)
+    }
+    return [ idx, this._getMatchAt(idx) ]
+  }
+
+  _getMatchAt (idx) {
+    // Note: because we are storing matching grouped by properties
+    // this is a but nasty
+    let state = this._getState()
+    if (state.matches) {
+      for (let [, matches] of state.matches) {
+        if (idx >= matches.length) {
+          idx -= matches.length
+        } else {
+          return matches[idx]
+        }
+      }
+    }
+  }
+
+  _scrollToMatch (match) {
+    let state = this._getState()
+    // HACKIDHACK: instead of relying on rerendering, we toggle the hightlight here
+    // which is also much faster, and still pretty safe, because we throw markers on every change
+    if (state.marker) state.marker.el.removeClass('sm-active')
+    let tp = match.textProperty
+    let marker = tp.find(`.sm-find-marker[data-id="${match.id}"]`)
+    marker.el.addClass('sm-active')
+    state.marker = marker
+    tp.send('scrollElementIntoView', marker.el)
+  }
+
   _onTextPropertyChanged (path) {
     this._dirty.add(String(path))
   }
 
   _onDocumentChange () {
     this._updateSearch()
+  }
+
+  // Note: we keep an internal flag indicating that the next match navigation
+  // should be done relative the current selection rather than relative
+  // to the current match
+  _onSelectionChange () {
+    this._relativeToMatch = false
   }
 
   static defaultState () {
@@ -224,7 +313,10 @@ export default class FindAndReplaceManager {
       replacePattern: '',
       caseSensitive: false,
       fullWord: false,
-      regexSearch: false
+      regexSearch: false,
+      matches: null,
+      count: 0,
+      cursor: 0
     }
   }
 }

--- a/src/kit/styles/_find-and-replace.css
+++ b/src/kit/styles/_find-and-replace.css
@@ -41,3 +41,7 @@
 .sc-annotation.sm-find-marker {
   background-color: yellow;
 }
+
+.sc-annotation.sm-find-marker.sm-active {
+  background-color: darkgoldenrod;
+}

--- a/src/kit/ui/ScrollPane.js
+++ b/src/kit/ui/ScrollPane.js
@@ -211,20 +211,26 @@ export default class ScrollPane extends AbstractScrollPane {
   scrollTo (selector, onlyIfNotVisible) {
     // console.log('ScrollPane.scrollTo()', selector)
     let scrollableEl = this.getScrollableElement()
-    let targetNode = scrollableEl.find(selector)
-    if (targetNode) {
-      const offset = this.getPanelOffsetForElement(targetNode)
-      let shouldScroll = true
-      if (onlyIfNotVisible) {
-        const height = scrollableEl.height
-        const oldOffset = scrollableEl.getProperty('scrollTop')
-        shouldScroll = (offset < oldOffset || oldOffset + height < offset)
-      }
-      if (shouldScroll) {
-        this.setScrollPosition(offset)
-      }
+    let el = scrollableEl.find(selector)
+    if (el) {
+      this.scrollElementIntoView(el, onlyIfNotVisible)
     } else {
       console.warn(`No match found for selector '${selector}' in scrollable container`)
+    }
+  }
+
+  scrollElementIntoView (el, onlyIfNotVisible) {
+    // console.log('ScrollPane.scrollTo()', selector)
+    let scrollableEl = this.getScrollableElement()
+    const offset = this.getPanelOffsetForElement(el)
+    let shouldScroll = true
+    if (onlyIfNotVisible) {
+      const height = scrollableEl.height
+      const oldOffset = scrollableEl.getProperty('scrollTop')
+      shouldScroll = (offset < oldOffset || oldOffset + height < offset)
+    }
+    if (shouldScroll) {
+      this.setScrollPosition(offset)
     }
   }
 


### PR DESCRIPTION
Continuing the work started in #716: Specifically enabling search result navigation (next / previous).