### PR TITLE
Fix regression in SurfaceManager

### DIFF
--- a/src/kit/app/SurfaceManager.js
+++ b/src/kit/app/SurfaceManager.js
@@ -5,8 +5,7 @@ export default class SurfaceManager {
     this.editorState = editorState
     this.surfaces = {}
 
-    editorState.addObserver(['selection'], this._onSelectionChange, this, { stage: 'post-render' })
-    editorState.addObserver(['selection', 'document'], this._recoverDOMSelection, this, { stage: 'post-render' })
+    editorState.addObserver(['selection', 'document'], this._onSelectionOrDocumentChange, this, { stage: 'post-render' })
     editorState.addObserver(['selection', 'document'], this._scrollSelectionIntoView, this, { stage: 'finalize' })
   }
 
@@ -41,18 +40,25 @@ export default class SurfaceManager {
     }
   }
 
-  _onSelectionChange () {
+  _onSelectionOrDocumentChange () {
     // console.log('SurfaceManager._onSelectionChange()')
-    const selection = this.editorState.selection
-    // update state.focusedSurface
-    this._reduceFocusedSurface(selection)
-    // HACK: removing DOM selection *and* blurring when having a CustomSelection
-    // otherwise we will receive events on the wrong surface
-    // instead of bubbling up to GlobalEventManager
-    if (selection && selection.isCustomSelection() && platform.inBrowser) {
-      window.getSelection().removeAllRanges()
-      window.document.activeElement.blur()
+
+    // Reducing state.focusedSurface (only if selection has changed)
+    if (this.editorState.isDirty('selection')) {
+      const selection = this.editorState.selection
+      // update state.focusedSurface
+      this._reduceFocusedSurface(selection)
+      // HACK: removing DOM selection *and* blurring when having a CustomSelection
+      // otherwise we will receive events on the wrong surface
+      // instead of bubbling up to GlobalEventManager
+      if (selection && selection.isCustomSelection() && platform.inBrowser) {
+        window.getSelection().removeAllRanges()
+        window.document.activeElement.blur()
+      }
     }
+
+    // TODO: this still needs to be improved. The DOM selection can be affected by other updates than document changes
+    this._recoverDOMSelection()
   }
 
   _reduceFocusedSurface (sel) {

--- a/src/kit/app/SurfaceManager.js
+++ b/src/kit/app/SurfaceManager.js
@@ -84,7 +84,7 @@ export default class SurfaceManager {
     let focusedSurface = editorState.focusedSurface
     // console.log('focusedSurface', focusedSurface)
     if (focusedSurface && !focusedSurface.isDisabled()) {
-      // console.log('Rendering selection on surface', focusedSurface.getId(), this.editorSession.getSelection().toString());
+      // console.log('Rendering selection on surface', focusedSurface.getId(), this.editorState.selection.toString())
       focusedSurface._focus()
       focusedSurface.rerenderDOMSelection()
     } else {

--- a/src/kit/ui/AbstractScrollPane.js
+++ b/src/kit/ui/AbstractScrollPane.js
@@ -92,10 +92,17 @@ export default class AbstractScrollPane extends Component {
   }
 
   _scrollSelectionIntoView () {
+    // console.log('AbstractScrollPane._scrollSelectionIntoView()')
     let hints = this.context.appState.get('overlayHints')
-    if (!hints) return
+    if (!hints) {
+      // console.log('...no hints')
+      return
+    }
     let selectionRect = hints.selectionRect
-    if (!selectionRect) return
+    if (!selectionRect) {
+      // console.log('...no selection rect')
+      return
+    }
     let upperBound = this.getScrollPosition()
     let lowerBound = upperBound + this.getHeight()
     let selTop = selectionRect.top

--- a/src/shared/vfsSaveHook.js
+++ b/src/shared/vfsSaveHook.js
@@ -5,7 +5,7 @@ export default function vfsSaveHook (storage, ArchiveClass) {
   // monkey patch VfsStorageClient so that we can check if the stored data
   // can be loaded
   storage.write = (archiveId, rawArchive, cb) => {
-    console.log('Writing archive:', rawArchive) // eslint-disable-line
+    console.info('Writing archive:', rawArchive) // eslint-disable-line
     storage.read(archiveId, (err, originalRawArchive) => {
       if (err) return cb(err)
       rawArchive.resources = Object.assign({}, originalRawArchive.resources, rawArchive.resources)


### PR DESCRIPTION
We have introduced a regression recently which lead to calling `SurfaceManger._reduceFocusSurface()` and `SurfaceManager._recoverSelection()` in wrong order.