### PR TITLE
Render message for broken images

### DIFF
--- a/src/article/editor/styles/_graphic.css
+++ b/src/article/editor/styles/_graphic.css
@@ -2,3 +2,13 @@
   display: block;
   width: 100%;
 }
+
+.sc-graphic .se-error { 
+  border: 1px solid #d95859;
+  padding: 20px;
+  color: #d95859;
+}
+
+.sc-graphic .se-error .se-icon { 
+  margin-right: 10px;
+}

--- a/src/article/shared/GraphicComponent.js
+++ b/src/article/shared/GraphicComponent.js
@@ -11,9 +11,25 @@ export default class GraphicComponent extends NodeComponent {
     let el = $$('div')
       .addClass('sc-graphic')
       .attr('data-id', node.id)
+
+    if (this.state.errored) {
+      el.append(
+        $$('div').addClass('se-error').append(
+          this.context.iconProvider.renderIcon($$, 'graphic-load-error').addClass('se-icon'),
+          this.getLabel('graphic-load-error')
+        )
+      )
+      return el
+    }
+
     el.append(
       $$('img').attr({src: url}).ref('image')
+        .on('error', this._onLoadError)
     )
     return el
+  }
+
+  _onLoadError () {
+    this.extendState({errored: true})
   }
 }

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -96,5 +96,9 @@ export default {
 
     config.addLabel('references', 'References')
     config.addLabel('footnotes', 'Footnotes')
+
+    // Used for rendering warning in case of missing images
+    config.addIcon('graphic-load-error', { 'fontawesome': 'fa-warning' })
+    config.addLabel('graphic-load-error', 'We couldn\'t load an image, sorry.')
   }
 }


### PR DESCRIPTION
## Why

As reported in #193 broken images causing image flickering and scroll jumping.

## What

For now on we are listening for error events in img element of graphic component. In that case we are changing the state and rendering a warning message. 