### PR TITLE
Target types for body

### DIFF
--- a/src/article/InternalArticleSchema.js
+++ b/src/article/InternalArticleSchema.js
@@ -1,6 +1,7 @@
 import {
   DocumentSchema, DocumentNode, InlineNode,
-  XMLContainerNode, XMLElementNode, XMLTextElement
+  XMLContainerNode, XMLElementNode, XMLTextElement,
+  without
 } from 'substance'
 import { BOOLEAN, STRING, TEXT, MANY, ONE, CHILDREN, CHILD } from '../kit'
 import { INTERNAL_BIBR_TYPES } from './ArticleConstants'
@@ -164,6 +165,16 @@ Title.schema = {
 
 class Abstract extends TranslatableContainerElement {}
 Abstract.type = 'abstract'
+
+// In contrast to TextureJATS, our internal <body> does not have <sec> but <heading> instead
+let TextureBody = TextureArticleSchema.getNodeClass('body', 'strict')
+const bodyTargetTypes = without(TextureBody.schema.getProperty('_childNodes').targetTypes, 'sec').concat(['heading'])
+
+class Body extends XMLContainerNode {}
+Body.schema = {
+  type: 'body',
+  _childNodes: CHILDREN(...bodyTargetTypes)
+}
 
 class Heading extends XMLTextElement {
   getLevel () {
@@ -788,6 +799,7 @@ const InternalArticleSchema = new DocumentSchema({
 InternalArticleSchema.addNodes([
   Article,
   ArticleRef,
+  Body,
   // metadata
   Metadata,
   ArticleRecord,
@@ -851,7 +863,6 @@ InternalArticleSchema.addNodes([
 // Elements taken from the JATS spec
 // TODO: make sure that we do not need to modify them, e.g. marking them as inline nodes
 InternalArticleSchema.addNodes([
-  'body',
   'bio',
   'caption',
   'code',

--- a/test/ManuscriptEditor.test.js
+++ b/test/ManuscriptEditor.test.js
@@ -6,13 +6,11 @@ import setupTestApp from './setupTestApp'
 
 test('ManuscriptEditor: add figure', t => {
   let { app } = setupTestApp(t)
-  let articlePanel = app.find('.sc-article-panel')
-  articlePanel.send('updateViewName', 'manuscript')
-  let editor = articlePanel.find('.sc-manuscript-editor')
+  let editor = _openManuscriptEditor(app)
   setCursor(editor, 'p-2.content', 290)
   // ATTENTION: it is not possible to trigger the file-dialog programmatically
   // instead we are just checking that this does not throw
-  let insertFigureTool = articlePanel.find('.sc-insert-figure-tool')
+  let insertFigureTool = editor.find('.sc-insert-figure-tool')
   t.ok(insertFigureTool.find('button').click(), 'clicking on the insert figure button should not throw')
   // ... and then triggering onFileSelect() directly
   insertFigureTool.onFileSelect(new PseudoFileEvent())
@@ -24,9 +22,7 @@ test('ManuscriptEditor: add figure', t => {
 
 test('ManuscriptEditor: TOC should be updated on change', t => {
   let { app } = setupTestApp(t)
-  let articlePanel = app.find('.sc-article-panel')
-  articlePanel.send('updateViewName', 'manuscript')
-  let editor = articlePanel.find('.sc-manuscript-editor')
+  let editor = _openManuscriptEditor(app)
   let toc = editor.find('.sc-toc')
   editor.context.editorSession.transaction(tx => {
     tx.set(['sec-1', 'content'], 'TEST')
@@ -35,6 +31,35 @@ test('ManuscriptEditor: TOC should be updated on change', t => {
   t.equal(h1.el.text(), 'TEST', 'TOC entry should have been updated')
   t.end()
 })
+
+test('ManuscriptEditor: Switch paragraph to heading', t => {
+  let { app } = setupTestApp(t, { archiveId: 'blank' })
+  let editor = _openManuscriptEditor(app)
+  editor.context.editorSession.transaction(tx => {
+    let body = tx.get('body')
+    body.append(tx.create({
+      type: 'p',
+      id: 'p1'
+    }))
+  })
+  setCursor(editor, 'p1.content', 0)
+  // open the switch type dropdown
+  let switchTypeDropdown = editor.find('.sc-tool-dropdown.sm-text-types')
+  switchTypeDropdown.find('button').click()
+  let h1button = switchTypeDropdown.find('.sc-menu-item.sm-heading1')
+  t.notNil(h1button, 'there should be an option to switch to heading level 1')
+  h1button.click()
+  // ATTENTION: we do not change id, which might be confusing for others
+  let h1El = editor.find('.sc-surface.body > h1')
+  t.notNil(h1El, 'there should be a <h1> element now')
+  t.end()
+})
+
+function _openManuscriptEditor (app) {
+  let articlePanel = app.find('.sc-article-panel')
+  articlePanel.send('updateViewName', 'manuscript')
+  return articlePanel.find('.sc-manuscript-editor')
+}
 
 class PseudoFileEvent {
   constructor () {

--- a/test/integrationTestHelpers.js
+++ b/test/integrationTestHelpers.js
@@ -1,21 +1,26 @@
 /* global vfs, TEST_VFS */
-import { ObjectOperation, DocumentChange, isString } from 'substance'
+import { ObjectOperation, DocumentChange, isString, isArray } from 'substance'
 import { TextureWebApp, VfsStorageClient } from '../index'
 import TestVfs from './TestVfs'
 
 export function setCursor (editor, path, pos) {
-  if (!isString(path)) {
+  if (isArray(path)) {
     path = path.join('.')
   }
   let property = editor.find(`.sc-text-property[data-path=${path.replace('.', '\\.')}]`)
   if (!property) {
     throw new Error('Could not find text property for path ' + path)
   }
-  let editorSession = editor.context.editorSession
+  setCursorIntoProperty(property, pos)
+}
+
+export function setCursorIntoProperty (property, pos) {
+  const path = property.getPath()
+  let editorSession = property.context.editorSession
   let surface = property.context.surface
   editorSession.setSelection({
     type: 'property',
-    path: path.split('.'),
+    path,
     startOffset: pos,
     surfaceId: surface.id,
     containerId: surface.containerId


### PR DESCRIPTION
## Why

See #755 

## What

Overrides the TextureJATS `<body>` specification to allow `<heading>` instead of `<sec>` as child element.