### PR TITLE
JATS snippets

### DIFF
--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -8,8 +8,10 @@ import renderEntity from './shared/renderEntity'
 import TranslateableModel from './models/TranslateableModel'
 import { REQUIRED_PROPERTIES } from './ArticleConstants'
 import TableEditingAPI from './shared/TableEditingAPI'
-import { generateTable } from './shared/tableHelpers'
-import { createEmptyElement, importFigure, setContainerSelection } from './articleHelpers'
+import {
+  createEmptyElement, importFigure,
+  insertTableFigure, setContainerSelection
+} from './articleHelpers'
 
 // TODO: this should come from configuration
 const COLLECTIONS = {
@@ -420,23 +422,8 @@ export default class ArticleAPI extends EditorAPI {
     })
   }
 
-  // TODO: Use JATS snippet for table creation
   _createTableFigure (tx, params) {
-    let caption = tx.createElement('caption').append(
-      tx.createElement('p')
-    )
-    let permission = tx.create({
-      type: 'permission'
-    })
-    let table = generateTable(tx, params.rows, params.columns)
-    let tableFigure = tx.create({
-      type: 'table-figure',
-      caption: caption.id,
-      content: table.id,
-      permission: permission.id
-    })
-
-    return tableFigure
+    return insertTableFigure(tx, params.rows, params.columns)
   }
 
   _insertFootnote (item, footnotes) {

--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -9,7 +9,7 @@ import TranslateableModel from './models/TranslateableModel'
 import { REQUIRED_PROPERTIES } from './ArticleConstants'
 import TableEditingAPI from './shared/TableEditingAPI'
 import {
-  createEmptyElement, importFigure,
+  createEmptyElement, importFigures,
   insertTableFigure, setContainerSelection
 } from './articleHelpers'
 
@@ -418,7 +418,7 @@ export default class ArticleAPI extends EditorAPI {
     let sel = articleSession.getSelection()
     if (!sel || !sel.containerId) return
     articleSession.transaction(tx => {
-      importFigure(tx, sel, files, paths)
+      importFigures(tx, sel, files, paths)
     })
   }
 

--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -440,9 +440,10 @@ export default class ArticleAPI extends EditorAPI {
   }
 
   _insertFootnote (item, footnotes) {
+    const collectionId = footnotes.id
     this.articleSession.transaction(tx => {
       const node = createEmptyElement(tx, 'footnote')
-      tx.get(footnotes._node.id).appendChild(
+      tx.get(collectionId).appendChild(
         node
       )
       setContainerSelection(tx, node)
@@ -461,6 +462,19 @@ export default class ArticleAPI extends EditorAPI {
       let newSelection = this._selectFirstRequiredProperty(node)
       tx.setSelection(newSelection)
     })
+
+    // TODO: for snippet importing we need to register a contrib converter
+    // and take care of groups
+
+    // const collectionId = collection.id
+    // this.articleSession.transaction(tx => {
+    //   const node = createEmptyElement(tx, 'person')
+    //   tx.get(collectionId).appendChild(
+    //     node
+    //   )
+    //   let newSelection = this._selectFirstRequiredProperty(node)
+    //   tx.setSelection(newSelection)
+    // })
   }
 
   _getSelection () {

--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -1,4 +1,4 @@
-import { without, selectionHelpers } from 'substance'
+import { without } from 'substance'
 import {
   DynamicCollection,
   StringModel, TextModel, FlowContentModel,
@@ -9,7 +9,7 @@ import TranslateableModel from './models/TranslateableModel'
 import { REQUIRED_PROPERTIES } from './ArticleConstants'
 import TableEditingAPI from './shared/TableEditingAPI'
 import { generateTable } from './shared/tableHelpers'
-import { createEmptyElement } from './articleHelpers'
+import { createEmptyElement, importFigure, setContainerSelection } from './articleHelpers'
 
 // TODO: this should come from configuration
 const COLLECTIONS = {
@@ -407,44 +407,16 @@ export default class ArticleAPI extends EditorAPI {
   }
 
   // TODO: can we improve this?
-  // 1. Here we would need a transaction on archive level, creating assets, plus placing them inside the article body.
-  // 2. It would be interesting to use a more generic interface maybe even JATS
-  // TODO: Use JATS snippet for figure creation
+  // Here we would need a transaction on archive level, creating assets, plus placing them inside the article body.
   _insertFigures (files) {
     const articleSession = this.articleSession
-    let LAST = files.length - 1
     let paths = files.map(file => {
       return this.archive.createFile(file)
     })
     let sel = articleSession.getSelection()
     if (!sel || !sel.containerId) return
-    let containerId = sel.containerId
     articleSession.transaction(tx => {
-      files.map((file, idx) => {
-        let path = paths[idx]
-        let mimeData = file.type.split('/')
-        let caption = tx.createElement('caption').append(
-          tx.createElement('p')
-        )
-        let graphic = tx.createElement('graphic').attr({
-          'mime-subtype': mimeData[1],
-          'mimetype': mimeData[0],
-          'xlink:href': path
-        })
-        let permission = tx.create({
-          type: 'permission'
-        })
-        let figure = tx.create({
-          type: 'figure',
-          caption: caption.id,
-          content: graphic.id,
-          permission: permission.id
-        })
-        tx.insertBlockNode(figure)
-        if (idx === LAST) {
-          selectionHelpers.selectNode(tx, figure.id, containerId)
-        }
-      })
+      importFigure(tx, sel, files, paths)
     })
   }
 
@@ -469,20 +441,11 @@ export default class ArticleAPI extends EditorAPI {
 
   _insertFootnote (item, footnotes) {
     this.articleSession.transaction(tx => {
-      // let node = tx.create(item)
-      // let p = tx.create({type: 'p'})
-      // node.append(p)
+      const node = createEmptyElement(tx, 'footnote')
       tx.get(footnotes._node.id).appendChild(
-        createEmptyElement(tx, 'footnote')
+        node
       )
-      // let path = [p.id, 'content']
-      // let newSelection = {
-      //   type: 'property',
-      //   path,
-      //   startOffset: 0,
-      //   surfaceId: node.id
-      // }
-      // tx.setSelection(newSelection)
+      setContainerSelection(tx, node)
     })
   }
 

--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -9,6 +9,7 @@ import TranslateableModel from './models/TranslateableModel'
 import { REQUIRED_PROPERTIES } from './ArticleConstants'
 import TableEditingAPI from './shared/TableEditingAPI'
 import { generateTable } from './shared/tableHelpers'
+import { createEmptyElement } from './articleHelpers'
 
 // TODO: this should come from configuration
 const COLLECTIONS = {
@@ -468,18 +469,20 @@ export default class ArticleAPI extends EditorAPI {
 
   _insertFootnote (item, footnotes) {
     this.articleSession.transaction(tx => {
-      let node = tx.create(item)
-      let p = tx.create({type: 'p'})
-      node.append(p)
-      tx.get(footnotes._node.id).appendChild(node)
-      let path = [p.id, 'content']
-      let newSelection = {
-        type: 'property',
-        path,
-        startOffset: 0,
-        surfaceId: node.id
-      }
-      tx.setSelection(newSelection)
+      // let node = tx.create(item)
+      // let p = tx.create({type: 'p'})
+      // node.append(p)
+      tx.get(footnotes._node.id).appendChild(
+        createEmptyElement(tx, 'footnote')
+      )
+      // let path = [p.id, 'content']
+      // let newSelection = {
+      //   type: 'property',
+      //   path,
+      //   startOffset: 0,
+      //   surfaceId: node.id
+      // }
+      // tx.setSelection(newSelection)
     })
   }
 

--- a/src/article/ArticleSnippets.js
+++ b/src/article/ArticleSnippets.js
@@ -24,6 +24,19 @@ export const FOOTNOTE_SNIPPET = `
   </fn>
 `
 
+export const PERSON_SNIPPET = `
+  <contrib contrib-type="person" equal-contrib="no" corresp="no" deceased="no">
+    <name>
+      <surname></surname>
+      <given-names></given-names>
+      <suffix></suffix>
+    </name>
+    <bio>
+      <p></p>
+    </bio>
+  </contrib>
+`
+
 export const TABLE_SNIPPET = `
   <table-wrap id="table1">
     <label></label>

--- a/src/article/ArticleSnippets.js
+++ b/src/article/ArticleSnippets.js
@@ -1,11 +1,11 @@
 export const FIGURE_SNIPPET = `
-  <fig>
+  <fig xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
     <label></label>
     <caption>
       <title></title>
       <p></p>
     </caption>
-    <graphic xmlns:xlink="http://www.w3.org/1999/xlink" mime-subtype="" mimetype="image" xlink:href="" />
+    <graphic mime-subtype="" mimetype="image" xlink:href="" />
     <permissions>
       <copyright-statement></copyright-statement>
       <copyright-year></copyright-year>
@@ -16,6 +16,12 @@ export const FIGURE_SNIPPET = `
       </license>
     </permissions>
   </fig>
+`
+
+export const FOOTNOTE_SNIPPET = `
+  <fn>
+    <p></p>
+  </fn>
 `
 
 export const TABLE_SNIPPET = `

--- a/src/article/ArticleSnippets.js
+++ b/src/article/ArticleSnippets.js
@@ -1,0 +1,51 @@
+export const FIGURE_SNIPPET = `
+  <fig>
+    <label></label>
+    <caption>
+      <title></title>
+      <p></p>
+    </caption>
+    <graphic xmlns:xlink="http://www.w3.org/1999/xlink" mime-subtype="" mimetype="image" xlink:href="" />
+    <permissions>
+      <copyright-statement></copyright-statement>
+      <copyright-year></copyright-year>
+      <copyright-holder></copyright-holder>
+      <license>
+        <ali:license_ref></ali:license_ref>
+        <license-p></license-p>
+      </license>
+    </permissions>
+  </fig>
+`
+
+export const TABLE_SNIPPET = `
+  <table-wrap id="table1">
+    <label></label>
+    <caption>
+      <title></title>
+      <p></p>
+    </caption>  
+    <table>
+      <tbody>
+        <tr>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+      </tbody>
+    </table>
+  </table-wrap>
+`

--- a/src/article/ArticleSnippets.js
+++ b/src/article/ArticleSnippets.js
@@ -1,69 +1,37 @@
-export const FIGURE_SNIPPET = `
+export const FIGURE_SNIPPET = () => `
   <fig xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
-    <label></label>
-    <caption>
-      <title></title>
-      <p></p>
-    </caption>
+    <caption></caption>
     <graphic mime-subtype="" mimetype="image" xlink:href="" />
-    <permissions>
-      <copyright-statement></copyright-statement>
-      <copyright-year></copyright-year>
-      <copyright-holder></copyright-holder>
-      <license>
-        <ali:license_ref></ali:license_ref>
-        <license-p></license-p>
-      </license>
-    </permissions>
   </fig>
 `
 
-export const FOOTNOTE_SNIPPET = `
-  <fn>
-    <p></p>
-  </fn>
+export const FOOTNOTE_SNIPPET = () => `
+  <fn></fn>
 `
 
-export const PERSON_SNIPPET = `
+export const PERSON_SNIPPET = () => `
   <contrib contrib-type="person" equal-contrib="no" corresp="no" deceased="no">
     <name>
       <surname></surname>
       <given-names></given-names>
       <suffix></suffix>
     </name>
-    <bio>
-      <p></p>
-    </bio>
+    <bio></bio>
   </contrib>
 `
 
-export const TABLE_SNIPPET = `
-  <table-wrap id="table1">
-    <label></label>
+export const TABLE_SNIPPET = (nrows, ncols) => `
+  <table-wrap>
     <caption>
-      <title></title>
-      <p></p>
     </caption>  
     <table>
       <tbody>
         <tr>
-          <th></th>
-          <th></th>
-          <th></th>
-          <th></th>
+          ${Array(ncols).fill().map(() => '<th></th>').join('')}
         </tr>
-        <tr>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
-        <tr>
-          <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
-        </tr>
+        ${Array(nrows).fill().map(() => `<tr>
+          ${Array(ncols).fill().map(() => '<td></td>').join('')}
+        </tr>`).join('')}
       </tbody>
     </table>
   </table-wrap>

--- a/src/article/articleHelpers.js
+++ b/src/article/articleHelpers.js
@@ -1,7 +1,6 @@
 import { DefaultDOMElement, importNodeIntoDocument, selectionHelpers } from 'substance'
 import createJatsImporter from './converter/r2t/createJatsImporter'
 import { FIGURE_SNIPPET, FOOTNOTE_SNIPPET, PERSON_SNIPPET, TABLE_SNIPPET } from './ArticleSnippets'
-import { generateTable } from './shared/tableHelpers'
 
 const elementSpippetsMap = {
   'figure': FIGURE_SNIPPET,

--- a/src/article/articleHelpers.js
+++ b/src/article/articleHelpers.js
@@ -1,6 +1,8 @@
 import { DefaultDOMElement, importNodeIntoDocument, selectionHelpers } from 'substance'
 import createJatsImporter from './converter/r2t/createJatsImporter'
 import { FIGURE_SNIPPET, FOOTNOTE_SNIPPET, PERSON_SNIPPET, TABLE_SNIPPET } from './ArticleSnippets'
+import { generateTable } from './shared/tableHelpers'
+
 const elementSpippetsMap = {
   'figure': FIGURE_SNIPPET,
   'footnote': FOOTNOTE_SNIPPET,
@@ -8,12 +10,12 @@ const elementSpippetsMap = {
   'table-figure': TABLE_SNIPPET
 }
 
-export function createEmptyElement (tx, elName) {
+export function createEmptyElement (tx, elName, ...snippetParams) {
   const snippet = elementSpippetsMap[elName]
   if (!snippet) {
     throw new Error('There is no snippet for element', elName)
   }
-  let snippetEl = DefaultDOMElement.parseSnippet(snippet.trim(), 'xml')
+  let snippetEl = DefaultDOMElement.parseSnippet(snippet(...snippetParams).trim(), 'xml')
   let docSnippet = tx.getDocument().createSnippet()
   let jatsImporter = createJatsImporter(docSnippet)
   let node = jatsImporter.convertElement(snippetEl)
@@ -52,4 +54,8 @@ export function importFigure (tx, sel, files, paths) {
       selectionHelpers.selectNode(tx, figure.id, containerId)
     }
   })
+}
+
+export function insertTableFigure (tx, rows, columns) {
+  return createEmptyElement(tx, 'table-figure', rows, columns)
 }

--- a/src/article/articleHelpers.js
+++ b/src/article/articleHelpers.js
@@ -1,0 +1,18 @@
+import { DefaultDOMElement } from 'substance'
+import createJatsImporter from './converter/r2t/createJatsImporter'
+import { FIGURE_SNIPPET, FOOTNOTE_SNIPPET, TABLE_SNIPPET } from './ArticleSnippets'
+const elementSpippetsMap = {
+  'figure': FIGURE_SNIPPET,
+  'footnote': FOOTNOTE_SNIPPET,
+  'table-figure': TABLE_SNIPPET
+}
+
+export function createEmptyElement (tx, elName) {
+  const snippet = elementSpippetsMap[elName]
+  if (!snippet) {
+    throw new Error('There is no snippet for element', elName)
+  }
+  let snippetEl = DefaultDOMElement.parseSnippet(snippet.trim(), 'xml')
+  let jatsImporter = createJatsImporter(tx)
+  return jatsImporter.convertElement(snippetEl)
+}

--- a/src/article/articleHelpers.js
+++ b/src/article/articleHelpers.js
@@ -1,4 +1,4 @@
-import { DefaultDOMElement } from 'substance'
+import { DefaultDOMElement, importNodeIntoDocument, selectionHelpers } from 'substance'
 import createJatsImporter from './converter/r2t/createJatsImporter'
 import { FIGURE_SNIPPET, FOOTNOTE_SNIPPET, TABLE_SNIPPET } from './ArticleSnippets'
 const elementSpippetsMap = {
@@ -13,6 +13,42 @@ export function createEmptyElement (tx, elName) {
     throw new Error('There is no snippet for element', elName)
   }
   let snippetEl = DefaultDOMElement.parseSnippet(snippet.trim(), 'xml')
-  let jatsImporter = createJatsImporter(tx)
-  return jatsImporter.convertElement(snippetEl)
+  let docSnippet = tx.getDocument().createSnippet()
+  let jatsImporter = createJatsImporter(docSnippet)
+  let node = jatsImporter.convertElement(snippetEl)
+  return importNodeIntoDocument(tx, node)
+}
+
+export function setContainerSelection (tx, node) {
+  const p = node.find('p')
+  if (p) {
+    let path = [p.id, 'content']
+    let newSelection = {
+      type: 'property',
+      path,
+      startOffset: 0,
+      surfaceId: node.id
+    }
+    tx.setSelection(newSelection)
+  }
+}
+
+export function importFigure (tx, sel, files, paths) {
+  let LAST = files.length - 1
+  let containerId = sel.containerId
+  files.map((file, idx) => {
+    let path = paths[idx]
+    let mimeData = file.type.split('/')
+    let figure = createEmptyElement(tx, 'figure')
+    let graphic = tx.get(figure.content)
+    graphic.attr({
+      'mime-subtype': mimeData[1],
+      'mimetype': mimeData[0],
+      'xlink:href': path
+    })
+    tx.insertBlockNode(figure)
+    if (idx === LAST) {
+      selectionHelpers.selectNode(tx, figure.id, containerId)
+    }
+  })
 }

--- a/src/article/articleHelpers.js
+++ b/src/article/articleHelpers.js
@@ -1,9 +1,10 @@
 import { DefaultDOMElement, importNodeIntoDocument, selectionHelpers } from 'substance'
 import createJatsImporter from './converter/r2t/createJatsImporter'
-import { FIGURE_SNIPPET, FOOTNOTE_SNIPPET, TABLE_SNIPPET } from './ArticleSnippets'
+import { FIGURE_SNIPPET, FOOTNOTE_SNIPPET, PERSON_SNIPPET, TABLE_SNIPPET } from './ArticleSnippets'
 const elementSpippetsMap = {
   'figure': FIGURE_SNIPPET,
   'footnote': FOOTNOTE_SNIPPET,
+  'person': PERSON_SNIPPET,
   'table-figure': TABLE_SNIPPET
 }
 

--- a/src/article/articleHelpers.js
+++ b/src/article/articleHelpers.js
@@ -35,7 +35,7 @@ export function setContainerSelection (tx, node) {
   }
 }
 
-export function importFigure (tx, sel, files, paths) {
+export function importFigures (tx, sel, files, paths) {
   let LAST = files.length - 1
   let containerId = sel.containerId
   files.map((file, idx) => {


### PR DESCRIPTION
## Why

Instead of doing custom transactions for some element insertions (like figures, tables or persons) we want to be able to do that via predefined JATS snippets.

## What

In this PR we want to introduce a new high-level API which will allow us to import a small parts of JATS document which we can later use for new elements insertion instead of manually crafted chain of transactions.