### PR TITLE
Empty content

### DIFF
--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -323,6 +323,7 @@ function _populateTitle (doc, jats, jatsImporter) {
 }
 
 function _populateAbstract (doc, jats, jatsImporter) {
+  let $$ = jats.createElement.bind(jats)
   // ATTENTION: JATS can have multiple abstracts
   // ATM we only take the first, loosing the others
   let abstractEls = jats.findAll('article > front > article-meta > abstract')
@@ -330,6 +331,10 @@ function _populateAbstract (doc, jats, jatsImporter) {
     let abstractEl = abstractEls[0]
     if (abstractEls.length > 1) {
       console.error('FIXME: Texture only supports one <abstract>.')
+    }
+    // if the abstract is empty, add an empty paragraph
+    if (abstractEl.getChildCount() === 0) {
+      abstractEl.append($$('p'))
     }
     let abstract = doc.get('abstract')
     abstractEl.children.forEach(el => {
@@ -355,10 +360,15 @@ function _populateAbstract (doc, jats, jatsImporter) {
 }
 
 function _populateBody (doc, jats, jatsImporter) {
+  let $$ = jats.createElement.bind(jats)
   // ATTENTION: JATS can have multiple abstracts
   // ATM we only take the first, loosing the others
   let bodyEl = jats.find('article > body')
   if (bodyEl) {
+    // add an empty paragraph if the body is empty
+    if (bodyEl.getChildCount() === 0) {
+      bodyEl.append($$('p'))
+    }
     let body = doc.get('body')
     // ATTENTION: because there is already a body node in the document, *the* body, with id 'body'
     // we must use change the id of the body element so that it does not collide with the internal one

--- a/src/article/shared/AbstractComponent.js
+++ b/src/article/shared/AbstractComponent.js
@@ -1,18 +1,6 @@
 import { Component } from 'substance'
 
 export default class AbstractComponent extends Component {
-  getInitialState () {
-    const model = this.props.model
-    const items = model.getItems()
-
-    // Attention: by default we hide empty abstracts
-    // TODO: this should be configurable
-    let isEmpty = items.length === 1 && items[0].getContent().isEmpty()
-    return {
-      hidden: isEmpty
-    }
-  }
-
   render ($$) {
     const model = this.props.model
     const ModelComponent = this.getComponent(model.type)
@@ -20,21 +8,17 @@ export default class AbstractComponent extends Component {
       .addClass('sc-abstract')
       .attr('data-id', model.id)
 
-    if (!this.state.hidden) {
-      el.append(
-        // TODO use label provider
-        $$('h1').addClass('sc-heading').append('Abstract')
-      )
-      el.append(
-        $$(ModelComponent, {
-          model: model,
-          placeholder: 'Enter Abstract',
-          name: 'abstractEditor'
-        })
-      )
-    } else {
-      el.addClass('sm-hidden')
-    }
+    el.append(
+      // TODO use label provider
+      $$('h1').addClass('sc-heading').append('Abstract')
+    )
+    el.append(
+      $$(ModelComponent, {
+        model: model,
+        placeholder: 'Enter Abstract',
+        name: 'abstractEditor'
+      })
+    )
     return el
   }
 }

--- a/src/kit/model/FlowContentComponent.js
+++ b/src/kit/model/FlowContentComponent.js
@@ -45,7 +45,8 @@ export default class FlowContentComponent extends ContainerEditorNew {
   }
 
   render ($$) {
-    return super.render($$).addClass('sc-flow-content')
+    let el = super.render($$).addClass('sc-flow-content')
+    return el
   }
 
   // overriding the default implementation, to control the behavior
@@ -79,6 +80,8 @@ export default class FlowContentComponent extends ContainerEditorNew {
     let props = super._getNodeProps(node)
     let model = this.context.api.getModelById(node.id)
     props.model = model
+    // TODO: get placeholder message using this.getLabel()
+    props.placeholder = `Enter ${this.props.label}`
     return props
   }
 }

--- a/src/kit/model/NodeModel.js
+++ b/src/kit/model/NodeModel.js
@@ -20,6 +20,15 @@ export default class NodeModel {
     return this._properties
   }
 
+  isEmpty () {
+    // TODO: what does isEmpty() mean on a general node?
+    // ATM we assume that this only makes sense for TextNodes
+    if (this._node.isText()) {
+      return this._node.isEmpty()
+    }
+    return false
+  }
+
   _initialize () {
     const api = this._api
     const node = this._node

--- a/src/kit/model/TextNodeComponent.js
+++ b/src/kit/model/TextNodeComponent.js
@@ -22,7 +22,8 @@ export default class TextNodeComponent extends Component {
       $$(TextPropertyComponent, {
         doc: node.getDocument(),
         name: path.join('.'),
-        path
+        path,
+        placeholder: this.props.placeholder
       }).ref('text')
     )
     // TODO: ability to edit attributes
@@ -34,6 +35,6 @@ export default class TextNodeComponent extends Component {
   }
 
   getClassNames () {
-    return 'sc-' + this.props.node.type
+    return 'sc-text-node sc-' + this.props.node.type
   }
 }

--- a/src/kit/model/_ContainerModel.js
+++ b/src/kit/model/_ContainerModel.js
@@ -14,7 +14,13 @@ export default class _ContainerModel extends ValueModel {
   }
 
   isEmpty () {
-    return this.getValue().length === 0
+    let ids = this.getValue()
+    if (ids.length === 0) return true
+    let first = this._api.getModelById(ids[0])
+    if (first && first.isEmpty) {
+      return first.isEmpty()
+    }
+    return false
   }
 
   _getItems () {

--- a/test/setupTestArticleSession.js
+++ b/test/setupTestArticleSession.js
@@ -21,6 +21,11 @@ export default function setupTestArticleSession (docInitializer) {
   let session = archive.getEditorSession('manuscript')
   let doc = session.getDocument()
   if (docInitializer) {
+    // clear the body
+    let body = doc.get('body')
+    body.removeAt(0)
+  }
+  if (docInitializer) {
     docInitializer(doc)
   }
   // NOTE: this indirection is necessary because we need to pass the context to parts of the context


### PR DESCRIPTION
## Why

See #731 

## What

This PR changes the importer to expand empty abstract and body.
Plus it fixes the problem of missing placeholders for flow-content types #749 and incorrect `isEmpty` #750 .