### PR TITLE
Remove ambiguous specification from TextureJATS.

### DIFF
--- a/src/article/TextureArticle.rng
+++ b/src/article/TextureArticle.rng
@@ -145,13 +145,10 @@
       <optional>
         <ref name="title-group"/>
       </optional>
-      <!-- we support 0..2 contrib groups, one for authors, one for editors -->
-      <optional>
+      <!-- TODO: find a better way to encode quantities here -->
+      <zeroOrMore>
         <ref name="contrib-group"/>
-      </optional>
-      <optional>
-        <ref name="contrib-group"/>
-      </optional>
+      </zeroOrMore>
       <zeroOrMore>
         <ref name="aff"/>
       </zeroOrMore>
@@ -465,10 +462,6 @@
       <optional>
         <ref name="abstract"/>
       </optional>
-      <optional>
-        <ref name="abstract"/>
-      </optional>
-      <!-- TODO: quantity? -->
       <zeroOrMore>
         <ref name="access.class"/>
       </zeroOrMore>


### PR DESCRIPTION
We need to use other means to ensure specific quantities.

See #438 

## What

This PR changes the `TextureJATS.rng` so that it is not ambiguous.