### PR TITLE
Open isolated nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lodash": "^4.14.1"
   },
   "peerDependency": {
-    "substance": "^1.0.0-preview.95"
+    "substance": "^1.0.0-preview.96"
   },
   "devDependencies": {
     "colors": "^1.3.2",
@@ -23,7 +23,7 @@
     "nyc": "11.8.0",
     "source-map-support": "0.5.3",
     "standard": "^11.0.1",
-    "substance": "1.0.0-preview.95",
+    "substance": "1.0.0-preview.96",
     "substance-bundler": "0.25.5",
     "substance-test": "0.12.3",
     "tap-spec": "^4.1.1"

--- a/src/kit/model/SubstanceModifications.js
+++ b/src/kit/model/SubstanceModifications.js
@@ -187,7 +187,15 @@ export class IsolatedNodeComponentNew extends SubstanceIsolatedNodeComponent {
     super(parent, props, options)
     if (!props.model) throw new Error("Property 'model' is required and must be a NodeModel")
     if (!props.model._node) throw new Error('Provided model must container a DocumentNode')
+
+    // HACK: overriding 'closed' IsolatedNodeComponents per se
+    // TODO: on the long term we need to understand if it may be better to open
+    // IsolatedNodes by default and only close them if needed.
+    // The UX is improved much also in browsers like FF.
+    // Still we need to evaluate this decision in the near future.
+    this.blockingMode = 'open'
   }
+
   _getContentProps () {
     let props = super._getContentProps()
     props.model = this.props.model


### PR DESCRIPTION
## Why

We believe that 'open' isolated nodes are the better UX choice in our case.

## What

This opens all IsolatedNodes per se.
