### PR TITLE
Fix table cell selection

### DIFF
--- a/src/article/shared/TableComponent.js
+++ b/src/article/shared/TableComponent.js
@@ -200,6 +200,7 @@ export default class TableComponent extends CustomSurface {
   }
 
   _onMousedown (e) {
+    // console.log('TableComponent._onMousedown()')
     e.stopPropagation()
     // TODO: do not update the selection if right-clicked and already having a selection
     if (platform.inBrowser) {

--- a/src/kit/model/SubstanceModifications.js
+++ b/src/kit/model/SubstanceModifications.js
@@ -304,8 +304,14 @@ function ModifiedSurface (Surface) {
     onMouseDown (event) {
       let res = super.onMouseDown(event)
       if (res !== false) {
+        // console.log('Surface.onMouseDown() stopping propagation.')
         event.stopPropagation()
       }
+    }
+
+    onMouseUp (e) {
+      // console.log('Surface.onMouseUp', this.id)
+      return super.onMouseUp(e)
     }
 
     onClick (event) {

--- a/src/kit/model/SubstanceModifications.js
+++ b/src/kit/model/SubstanceModifications.js
@@ -4,7 +4,9 @@ import {
   IsolatedNodeComponent as SubstanceIsolatedNodeComponent,
   IsolatedInlineNodeComponent as SubstanceIsolatedInlineNodeComponent,
   TextPropertyComponent as SubstanceTextPropertyComponent,
-  TextPropertyEditor as SubstanceTextPropertyEditor
+  TextPropertyEditor as SubstanceTextPropertyEditor,
+  platform,
+  DefaultDOMElement
 } from 'substance'
 
 import ClipboardNew from './ClipboardNew'
@@ -301,17 +303,94 @@ function ModifiedSurface (Surface) {
       this.clipboard.paste(clipboardData, this.context)
     }
 
+    // mostly copied from 'Substance.Surface.onMouseDown()'
+    // trying to improve the mouse handling
+    // not letting bubble up handled events
     onMouseDown (event) {
-      let res = super.onMouseDown(event)
-      if (res !== false) {
-        // console.log('Surface.onMouseDown() stopping propagation.')
-        event.stopPropagation()
+      if (!this._shouldConsumeEvent(event)) {
+        // console.log('skipping mousedown', this.id)
+        return false
+      }
+      // stopping propagation because now the event is considered to be handled
+      event.stopPropagation()
+
+      // EXPERIMENTAL: trying to 'reserve' a mousedown event
+      // so that parents know that they shouldn't react
+      // This is similar to event.stopPropagation() but without
+      // side-effects.
+      // Note: some browsers do not do clicks, selections etc. on children if propagation is stopped
+      if (event.__reserved__) {
+        // console.log('%s: mousedown already reserved by %s', this.id, event.__reserved__.id)
+        return
+      } else {
+        // console.log('%s: taking mousedown ', this.id)
+        event.__reserved__ = this
+      }
+
+      // NOTE: this is here to make sure that this surface is contenteditable
+      // For instance, IsolatedNodeComponent sets contenteditable=false on this element
+      // to achieve selection isolation
+      if (this.isEditable()) {
+        this.el.setAttribute('contenteditable', true)
+      }
+
+      // TODO: what is this exactly?
+      if (event.button !== 0) {
+        return
+      }
+
+      // special treatment for triple clicks
+      if (!(platform.isIE && platform.version < 12) && event.detail >= 3) {
+        let sel = this.getEditorSession().getSelection()
+        if (sel.isPropertySelection()) {
+          this._selectProperty(sel.path)
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        } else if (sel.isContainerSelection()) {
+          this._selectProperty(sel.startPath)
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+      }
+      // 'mouseDown' is triggered before 'focus' so we tell
+      // our focus handler that we are already dealing with it
+      // The opposite situation, when the surface gets focused e.g. using keyboard
+      // then the handler needs to kick in and recover a persisted selection or such
+      this._state.skipNextFocusEvent = true
+
+      // this is important for the regular use case, where the mousup occurs within this component
+      this.el.on('mouseup', this.onMouseUp, this)
+      // NOTE: additionally we need to listen to mousup on document to catch events outside the surface
+      // TODO: it could still be possible not to receive this event, if mouseup is triggered on a component that consumes the event
+      if (platform.inBrowser) {
+        let documentEl = DefaultDOMElement.wrapNativeElement(window.document)
+        documentEl.on('mouseup', this.onMouseUp, this)
       }
     }
 
     onMouseUp (e) {
       // console.log('Surface.onMouseUp', this.id)
-      return super.onMouseUp(e)
+      this.el.off('mouseup', this.onMouseUp, this)
+      if (platform.inBrowser) {
+        let documentEl = DefaultDOMElement.wrapNativeElement(window.document)
+        documentEl.off('mouseup', this.onMouseUp, this)
+      }
+      // console.log('Surface.onMouseup', this.id);
+      // ATTENTION: filtering events does not make sense here,
+      // as we need to make sure that pick the selection even
+      // when the mouse is released outside the surface
+      // if (!this._shouldConsumeEvent(e)) return
+      e.stopPropagation()
+      // ATTENTION: this delay is necessary for cases the user clicks
+      // into an existing selection. In this case the window selection still
+      // holds the old value, and is set to the correct selection after this
+      // being called.
+      this._delayed(() => {
+        let sel = this.domSelection.getSelection()
+        this._setSelection(sel)
+      })
     }
 
     onClick (event) {


### PR DESCRIPTION
## Why

see #905 

## What

Let's Surface also listen to mouseup locally, not only on document, so it receives the event before any parent (here IsolatedNode), which could block it.