### PR TITLE
Footnote issues

### DIFF
--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -464,7 +464,9 @@ export default class ArticleAPI extends EditorAPI {
   _insertFootnote (item, footnotes) {
     const collectionId = footnotes.id
     this.articleSession.transaction(tx => {
-      const node = createEmptyElement(tx, 'footnote')
+      const node = createEmptyElement(tx, 'footnote').append(
+        tx.create({type: 'p'})
+      )
       tx.get(collectionId).appendChild(
         node
       )

--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -386,9 +386,14 @@ function _populateBody (doc, jats, jatsImporter) {
 }
 
 function _populateFootnotes (doc, jats, jatsImporter) {
+  let $$ = jats.createElement.bind(jats)
   let fnEls = jats.findAll('article > back > fn-group > fn')
   let footnotes = doc.get('footnotes')
   fnEls.forEach(fnEl => {
+    // there must be at least one paragraph
+    if (!fnEl.find('p')) {
+      fnEl.append($$('p'))
+    }
     footnotes.append(jatsImporter.convertElement(fnEl))
   })
 }

--- a/src/article/editor/styles/_footnote.css
+++ b/src/article/editor/styles/_footnote.css
@@ -1,5 +1,7 @@
 .sc-footnote .se-container {
+  position: relative;
   display: flex;
+  align-items: baseline;
 }
 
 .sc-footnote .se-container .se-label {
@@ -9,4 +11,8 @@
   font-weight: var(--t-bold-font-weight);
   text-align: center;
   cursor: default;
+}
+
+.sc-footnote .se-container .sc-fn {
+  width: 100%;
 }

--- a/test/MetadataEditor.test.js
+++ b/test/MetadataEditor.test.js
@@ -35,8 +35,16 @@ test(`MetadataEditor: clicking on "Add Translation" should not select card (#838
   t.end()
 })
 
+test(`MetadataEditor: putting a cursor inside a newly created footnote (#947)`, t => {
+  t.end()
+})
+
+test(`MetadataEditor: after adding a new footnote it should be selected (#948)`, t => {
+  t.end()
+})
+
 function _setup (t, seedXML) {
-  let testVfs = createTestVfs(TRANSLATED_TITLE)
+  let testVfs = createTestVfs(seedXML)
   let {app} = setupTestApp(t, {
     vfs: testVfs,
     archiveId: 'test'

--- a/test/MetadataEditor.test.js
+++ b/test/MetadataEditor.test.js
@@ -23,6 +23,22 @@ const TRANSLATED_TITLE = `<?xml version="1.0" encoding="UTF-8"?>
   </back>
 </article>`
 
+const EMPTY_ARTICLE = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving DTD v1.0 20120330//EN" "JATS-journalarchiving.dtd">
+<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0">
+  <front>
+    <article-meta>
+      <title-group>
+        <article-title></article-title>
+      </title-group>
+    </article-meta>
+  </front>
+  <body>
+  </body>
+  <back>
+  </back>
+</article>`
+
 test(`MetadataEditor: clicking on "Add Translation" should not select card (#838)`, t => {
   let { editor } = _setup(t, TRANSLATED_TITLE)
   let translatableEditor = editor.find('.sc-translatable-editor')
@@ -35,11 +51,21 @@ test(`MetadataEditor: clicking on "Add Translation" should not select card (#838
   t.end()
 })
 
-test(`MetadataEditor: putting a cursor inside a newly created footnote (#947)`, t => {
+test(`MetadataEditor: a newly created footnote should contain at least one parapgraph (#947)`, t => {
+  let { editor } = _setup(t, EMPTY_ARTICLE)
+  _addItem(editor, 'footnote')
+  let fnEditor = editor.find('.sc-footnote .sc-fn')
+  let paragraphs = fnEditor.findAll('.sc-p')
+  t.ok(paragraphs.length > 0, 'There should be some paragraphs')
   t.end()
 })
 
-test(`MetadataEditor: after adding a new footnote it should be selected (#948)`, t => {
+test(`MetadataEditor: after adding a new footnote cursor should be inside (#948)`, t => {
+  let { editor } = _setup(t, EMPTY_ARTICLE)
+  _addItem(editor, 'footnote')
+  let sel = getSelection(editor)
+  let isContentPropertySelection = sel && sel.isPropertySelection() && sel.getPath()[1] === 'content'
+  t.ok(isContentPropertySelection, 'The footnote content should be selected')
   t.end()
 })
 
@@ -51,4 +77,11 @@ function _setup (t, seedXML) {
   })
   let editor = openMetadataEditor(app)
   return { editor }
+}
+
+function _addItem (metadataEditor, modelName) {
+  // open the add drop down
+  let addDropDown = metadataEditor.find('.sc-tool-dropdown.sm-add')
+  addDropDown.find('button').click()
+  addDropDown.find('.sc-menu-item.sm-add-' + modelName).click()
 }


### PR DESCRIPTION
## Why

Currently there are couple of problems with new or empty footnotes, see #947, #948.

## What

This PR contains tests which reveals problems and fixes. I'm manually appending empty paragraph during creation and during jats2internal conversion for empty paragraphs (could imagine that someone would like to open article with empty fn element, why not?). Don't like this solution very much, the alternative could be probably a custom converter, but don't want to do it know. I think we need to collect and analyse more cases and then decide how we want to nail this empty paragraphs problems for containers generally.
Also here is a minor style fix.
