### PR TITLE
Issue title for article meta

### DIFF
--- a/data/kitchen-sink/manuscript.xml
+++ b/data/kitchen-sink/manuscript.xml
@@ -106,6 +106,7 @@
       </pub-date>
       <volume>318</volume>
       <issue>7187</issue>
+      <issue-title xml:lang="fr">Des zones d’incertitudes en traduction</issue-title>
       <fpage>837</fpage>
       <lpage>841</lpage>
       <page-range>837-841</page-range>

--- a/data/kitchen-sink/manuscript.xml
+++ b/data/kitchen-sink/manuscript.xml
@@ -106,7 +106,7 @@
       </pub-date>
       <volume>318</volume>
       <issue>7187</issue>
-      <issue-title xml:lang="fr">Des zones d’incertitudes en traduction</issue-title>
+      <issue-title>Des zones d’incertitudes en traduction</issue-title>
       <fpage>837</fpage>
       <lpage>841</lpage>
       <page-range>837-841</page-range>

--- a/docs/TextureArticle.md
+++ b/docs/TextureArticle.md
@@ -128,7 +128,7 @@ id, xml:base
 </pre>
 **Contains**:
 <pre style="white-space:pre-wrap;">
-article-id*,article-categories?,title-group?,contrib-group*,aff*,pub-date*,volume?,issue?,isbn?,(((fpage,lpage?)?,page-range?)|elocation-id)?,history?,permissions?,abstract?,trans-abstract*,kwd-group*,funding-group*
+article-id*,article-categories?,title-group?,contrib-group*,aff*,pub-date*,volume?,issue?,issue-title?,isbn?,(((fpage,lpage?)?,page-range?)|elocation-id)?,history?,permissions?,abstract?,trans-abstract*,kwd-group*,funding-group*
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
@@ -958,6 +958,21 @@ TEXT
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
 article-meta, element-citation
+</pre>
+
+### `<issue-title>`
+
+**Attributes**:
+<pre style="white-space:pre-wrap;">
+id, xml:base, content-type, specific-use, xml:lang
+</pre>
+**Contains**:
+<pre style="white-space:pre-wrap;">
+TEXT
+</pre>
+**This element may be contained in:**
+<pre style="white-space:pre-wrap;">
+article-meta
 </pre>
 
 ### `<italic>`
@@ -2062,7 +2077,6 @@ and explanations that help understanding the use-case.
 - issue-id
 - issue-part
 - issue-sponsor
-- issue-title
 - journal-id
 - journal-meta
 - journal-subtitle

--- a/docs/TextureArticle.md
+++ b/docs/TextureArticle.md
@@ -252,7 +252,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<break>`
@@ -717,7 +717,7 @@ id, xml:base, content-type, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<fn>`
@@ -968,7 +968,7 @@ id, xml:base, content-type, specific-use, xml:lang
 </pre>
 **Contains**:
 <pre style="white-space:pre-wrap;">
-TEXT
+(TEXT|bold|fixed-case|italic|monospace|overline|overline-start|overline-end|roman|sans-serif|sc|strike|underline|underline-start|underline-end|ruby|sub|sup)*
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
@@ -987,7 +987,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<kwd>`
@@ -1122,7 +1122,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<month>`
@@ -1212,7 +1212,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<p>`
@@ -1497,7 +1497,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<season>`
@@ -1587,7 +1587,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<string-date>`
@@ -1632,7 +1632,7 @@ id, xml:base, arrange, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<subj-group>`
@@ -1692,7 +1692,7 @@ id, xml:base, arrange, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<surname>`
@@ -1932,7 +1932,7 @@ id, xml:base, toggle, underline-style, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<uri>`

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "jsnext:main": "index.js",
   "dependencies": {
     "fs-extra": "^5.0.0",
-    "substance": "1.0.0-preview.105",
+    "substance": "1.0.0-preview.107",
     "yauzl": "^2.10.0",
     "yazl": "^2.4.3"
   },
   "peerDependency": {
-    "substance": "^1.0.0-preview.105"
+    "substance": "^1.0.0-preview.107"
   },
   "devDependencies": {
     "colors": "^1.3.2",

--- a/src/article/InternalArticleSchema.js
+++ b/src/article/InternalArticleSchema.js
@@ -26,6 +26,7 @@ ArticleRecord.schema = {
   type: 'article-record',
   volume: STRING,
   issue: STRING,
+  'issue-title': STRING,
   fpage: STRING,
   lpage: STRING,
   pageRange: STRING,

--- a/src/article/InternalArticleSchema.js
+++ b/src/article/InternalArticleSchema.js
@@ -26,7 +26,7 @@ ArticleRecord.schema = {
   type: 'article-record',
   volume: STRING,
   issue: STRING,
-  'issue-title': STRING,
+  'issue-title': TEXT(...RICH_TEXT_ANNOS),
   fpage: STRING,
   lpage: STRING,
   pageRange: STRING,

--- a/src/article/TextureArticle.rng
+++ b/src/article/TextureArticle.rng
@@ -859,7 +859,12 @@
   <define name="issue-title">
     <element name="issue-title">
       <ref name="issue-title-attlist"/>
-      <text/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="rich-text"/>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
 

--- a/src/article/TextureArticle.rng
+++ b/src/article/TextureArticle.rng
@@ -94,7 +94,6 @@
   <s:not-implemented name="issn-l"/>
   <s:not-implemented name="issue-id"/>
   <s:not-implemented name="issue-part"/>
-  <s:not-implemented name="issue-title"/>
   <s:not-implemented name="journal-id"/>
   <s:not-implemented name="journal-meta"/>
   <s:not-implemented name="journal-subtitle"/>
@@ -426,6 +425,9 @@
       </optional>
       <optional>
         <ref name="issue"/>
+      </optional>
+      <optional>
+        <ref name="issue-title"/>
       </optional>
       <optional>
         <ref name="isbn"/>
@@ -850,6 +852,13 @@
   <define name="issue">
     <element name="issue">
       <ref name="issue-attlist"/>
+      <text/>
+    </element>
+  </define>
+
+  <define name="issue-title">
+    <element name="issue-title">
+      <ref name="issue-title-attlist"/>
       <text/>
     </element>
   </define>

--- a/src/article/converter/r2t/internal2jats.js
+++ b/src/article/converter/r2t/internal2jats.js
@@ -129,7 +129,11 @@ function _populateArticleMeta (jats, doc, jatsExporter) {
 
   // issue-title?,
   if (articleRecord['issue-title']) {
-    articleMeta.append($$('issue-title').append(articleRecord['issue-title']))
+    articleMeta.append(
+      $$('issue-title').append(
+        jatsExporter.annotatedText([articleRecord.id, 'issue-title'])
+      )
+    )
   }
 
   // isbn?, // not supported yet

--- a/src/article/converter/r2t/internal2jats.js
+++ b/src/article/converter/r2t/internal2jats.js
@@ -127,6 +127,11 @@ function _populateArticleMeta (jats, doc, jatsExporter) {
     articleMeta.append($$('issue').append(articleRecord.issue))
   }
 
+  // issue-title?,
+  if (articleRecord['issue-title']) {
+    articleMeta.append($$('issue-title').append(articleRecord['issue-title']))
+  }
+
   // isbn?, // not supported yet
 
   // (((fpage,lpage?)?,page-range?)|elocation-id)?,

--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -317,7 +317,7 @@ function _populateTitle (doc, jats, jatsImporter) {
   let title = doc.get('title')
   let titleEl = jats.find('article > front > article-meta > title-group > article-title')
   if (titleEl) {
-    _convertAnnotatedText(jatsImporter, titleEl, title)
+    doc.set(title.getPath(), jatsImporter.annotatedText(titleEl, title.getPath()))
   }
   // translations
   let titleTranslations = jats.findAll('article > front > article-meta > title-group > trans-title-group > trans-title')
@@ -325,7 +325,7 @@ function _populateTitle (doc, jats, jatsImporter) {
     let group = transTitleEl.parentNode
     let language = group.attr('xml:lang')
     let translation = doc.create({ type: 'text-translation', id: transTitleEl.id, language })
-    _convertAnnotatedText(jatsImporter, transTitleEl, translation)
+    doc.set(translation.getPath(), jatsImporter.annotatedText(transTitleEl, translation.getPath()))
     return translation.id
   })
   title.assign({
@@ -414,17 +414,3 @@ function _populateReferences (doc, jats, jatsImporter) {
     })
   }
 }
-
-// Helpers
-
-function _convertAnnotatedText (jatsImporter, el, textNode) {
-  const doc = jatsImporter.state.doc
-  // NOTE: this is a bit difficult but necessary
-  // The importer maintains a stack of 'scopes' to deal with recursive calls
-  // triggered by converters for nesteded element (annotations and inline nodes)
-  jatsImporter.state.pushContext(el.tagName)
-  textNode.content = jatsImporter.annotatedText(el, textNode.getPath())
-  let context = jatsImporter.state.popContext()
-  context.annos.forEach(nodeData => doc.create(nodeData))
-}
-

--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -228,10 +228,13 @@ function _populateArticleRecord (doc, jats, jatsImporter) {
     fpage: getText(articleMetaEl, 'fpage'),
     lpage: getText(articleMetaEl, 'lpage'),
     issue: getText(articleMetaEl, 'issue'),
-    'issue-title': getText(articleMetaEl, 'issue-title'),
     volume: getText(articleMetaEl, 'volume'),
     pageRange: getText(articleMetaEl, 'page-range')
   })
+  let issueTitleEl = findChild(articleMetaEl, 'issue-title')
+  if (issueTitleEl) {
+    articleRecord['issue-title'] = jatsImporter.annotatedText(issueTitleEl, [articleRecord.id, 'issue-title'])
+  }
   // Import permission if present
   const permissionsEl = articleMetaEl.find('permissions')
   // An empty permission is already there, but will be replaced if <permission> element is there

--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -31,6 +31,7 @@ import createJatsImporter from './createJatsImporter'
       pub-date*,        // -> article-record
       volume?,          // -> article-record
       issue?,           // -> article-record
+      issue-title?,           // -> article-record
       isbn?,            // -> article-record
       (((fpage,lpage?)?,page-range?)|elocation-id)?,  // -> article-record
       history?,         // -> article-record
@@ -227,6 +228,7 @@ function _populateArticleRecord (doc, jats, jatsImporter) {
     fpage: getText(articleMetaEl, 'fpage'),
     lpage: getText(articleMetaEl, 'lpage'),
     issue: getText(articleMetaEl, 'issue'),
+    'issue-title': getText(articleMetaEl, 'issue-title'),
     volume: getText(articleMetaEl, 'volume'),
     pageRange: getText(articleMetaEl, 'page-range')
   })

--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -223,7 +223,7 @@ function _populateAwards (doc, jats) {
 function _populateArticleRecord (doc, jats, jatsImporter) {
   let articleMetaEl = jats.find('article > front > article-meta')
   let articleRecord = doc.get('article-record')
-  _assign(articleRecord, {
+  articleRecord.assign({
     elocationId: getText(articleMetaEl, 'elocation-id'),
     fpage: getText(articleMetaEl, 'fpage'),
     lpage: getText(articleMetaEl, 'lpage'),
@@ -233,7 +233,7 @@ function _populateArticleRecord (doc, jats, jatsImporter) {
   })
   let issueTitleEl = findChild(articleMetaEl, 'issue-title')
   if (issueTitleEl) {
-    articleRecord['issue-title'] = jatsImporter.annotatedText(issueTitleEl, [articleRecord.id, 'issue-title'])
+    articleRecord.set('issue-title', jatsImporter.annotatedText(issueTitleEl, [articleRecord.id, 'issue-title']))
   }
   // Import permission if present
   const permissionsEl = articleMetaEl.find('permissions')
@@ -243,7 +243,7 @@ function _populateArticleRecord (doc, jats, jatsImporter) {
     let permission = jatsImporter.convertElement(permissionsEl)
     // ATTENTION: so that the document model is correct we need to use
     // the Document API  to set the permission id
-    _assign(articleRecord, {
+    articleRecord.assign({
       permission: permission.id
     })
   }
@@ -255,7 +255,7 @@ function _populateArticleRecord (doc, jats, jatsImporter) {
       const date = _extractDate(dateEl)
       dates[date.type] = date.value
     })
-    _assign(articleRecord, dates)
+    articleRecord.assign(dates)
   }
 }
 
@@ -328,7 +328,7 @@ function _populateTitle (doc, jats, jatsImporter) {
     _convertAnnotatedText(jatsImporter, transTitleEl, translation)
     return translation.id
   })
-  _assign(title, {
+  title.assign({
     translations: translationIds
   })
 }
@@ -428,11 +428,3 @@ function _convertAnnotatedText (jatsImporter, el, textNode) {
   context.annos.forEach(nodeData => doc.create(nodeData))
 }
 
-// would be good to have this as a general Node API
-function _assign (node, obj) {
-  let doc = node.getDocument()
-  let props = Object.keys(obj)
-  for (let prop of props) {
-    doc.set([node.id, prop], obj[prop])
-  }
-}

--- a/src/article/shared/EntityLabelsPackage.js
+++ b/src/article/shared/EntityLabelsPackage.js
@@ -90,6 +90,7 @@ export default {
     config.addLabel('inventors', 'Inventors')
     config.addLabel('isbn', 'ISBN')
     config.addLabel('issue', 'Issue')
+    config.addLabel('issue-title', 'Issue Title')
     config.addLabel('lpage', 'Last Page')
     config.addLabel('month', 'Month')
     config.addLabel('name', 'Name')


### PR DESCRIPTION
## Why

Érudit requirement: Texture should support the editing of `issue title` in the metadata editing.

## What

This PR contains basic support of `issue title` inside `article-meta`.
Now we need to decide whatever do we want to support languages for this element.
And then we will need to decide if we want to support this element inside `element-citation`.
