### PR TITLE
Import CSL-JSON glitches

### DIFF
--- a/src/article/shared/ReferenceUploadComponent.js
+++ b/src/article/shared/ReferenceUploadComponent.js
@@ -21,8 +21,10 @@ export default class ReferenceUploadComponent extends Component {
         .append('select')
         .on('click', this._onClick),
       ' file',
-      $$('input').attr('type', 'file')
-        .on('click', this._supressClickPropagation)
+      $$('input').attr({
+        type: 'file',
+        accept: 'application/json'
+      }).on('click', this._supressClickPropagation)
         .on('change', this._selectFile)
         .ref('input')
     ).on('drop', this._handleDrop)
@@ -69,12 +71,9 @@ export default class ReferenceUploadComponent extends Component {
 
   _handleUploadedFiles (files) {
     Object.values(files).forEach(file => {
-      const isJSON = file.type.indexOf('application/json') === 0
-      if (isJSON) {
-        const reader = new window.FileReader()
-        reader.onload = this._onFileLoad.bind(this)
-        reader.readAsText(file)
-      }
+      const reader = new window.FileReader()
+      reader.onload = this._onFileLoad.bind(this)
+      reader.readAsText(file)
     })
   }
 

--- a/src/article/shared/styles/_add-reference-workflow.css
+++ b/src/article/shared/styles/_add-reference-workflow.css
@@ -17,9 +17,10 @@
 .se-add-reference > .se-doi-input > .se-input-group > .se-input {
   width: 100%;
   background: #f1f1f1;
-  padding: 7px 80px 7px 10px;
+  padding: 10px 80px 10px 10px;
   border: none;
   border-radius: 4px;
+  font-size: 16px;
 }
 
 .se-add-reference > .se-doi-input > .se-input-group > .se-action {


### PR DESCRIPTION
## Why

As Carlos reported in #942 there are some problems with uploading CSL-JSON references.
I think that it is an Electron glitches, in windows version you can't see MIME type of files uploaded through browser dialogs (e.g. file input). Since we are inspecting MIME type and expecting a JSON nothing happened.

## What

We are no longer inspecting MIME type, but asking file input to accept only JSON files. Which is not working for windows version of Electron :) But anyways wrong file format will lead to error in console during JSON parsing.

We should check if this bug exists in the next versions of Electron.