### PR TITLE
Table cell annos

### DIFF
--- a/data/kitchen-sink/manuscript.xml
+++ b/data/kitchen-sink/manuscript.xml
@@ -170,7 +170,7 @@
     </article-meta>
   </front>
   <body id="body">
-    <p id="p-2">Lorem <xref id="xref-1" ref-type="bibr" rid="r7">[1]</xref> ipsum <xref id="xref-2" ref-type="bibr" rid="r1">[2]</xref> dolor <ext-link id="ext-link-1" xmlns:xlink="http://www.w3.org/1999/xlink" ext-link-type="uri" xlink:href="http://substance.io">sit amet</ext-link>. Integer eget augue consequat, rhoncus velit nec, vehicula purus.</p>
+    <p id="p-2">Lorem <xref id="xref-1" ref-type="bibr" rid="r7">[1]</xref> ipsum <xref id="xref-2" ref-type="bibr" rid="r1">[2]</xref> dolor <ext-link id="ext-link-1" ext-link-type="uri" xlink:href="http://substance.io">sit amet</ext-link>. Formatting <bold id="p-2-bold-1">bold</bold>,<italic id="p2-italic-1">italic</italic>, <sub id="p2-sub-1">sub</sub>,<sup id="p2-sup-1">sup</sup>, <monospace id="p2-monospace-1">monospace</monospace>.</p>
     <sec id="sec-1">
       <title>Quisque malesuada</title>
       <table-wrap id="table1">
@@ -193,26 +193,26 @@
             </tr>
             <tr id="t1_3">
               <td id="t1_3_1">5</td>
-              <td id="t1_3_2" rowspan="2">6</td>
+              <td id="t1_3_2" rowspan="2">Formatting in table cell <bold id="t1-bold-1">bold</bold>,<italic id="t1-italic-1">italic</italic>, <sub id="t1-sub-1">sub</sub>,<sup id="t1-sup-1">sup</sup>, <monospace id="t1-monospace-1">monospace</monospace></td>
             </tr>
             <tr id="t1_4">
               <td id="t1_4_1">9</td>
-              <td id="t1_4_3">11</td>
-              <td id="t1_4_4">12</td>
+              <td id="t1_4_3">Hyper <ext-link  id="t1-ext-link-1" ext-link-type="uri" xlink:href="http://substance.io">link</ext-link> in table cell.</td>
+              <td id="t1_4_4">Reference citation in table cell <xref id="t1-xref-1" ref-type="bibr" rid="r7">[1]</xref></td>
             </tr>
           </tbody>
         </table>
       </table-wrap>
       <sec id="sec-2">
         <title>Orci varius natoque penatibus et magnis</title>
-        <p id="p-3">Lorem <xref id="xref-3" ref-type="fig" rid="fig1">Figure 1</xref> ipsum dolor<xref id="xref-4" ref-type="fn" rid="fn1">1</xref> sit amet <xref id="xref-5" ref-type="bibr" rid="r1 r7">[1,2]</xref>. Integer eget augue consequat, rhoncus velit nec, vehicula purus.</p>
+        <p id="p-3">Lorem <xref id="xref-3" ref-type="fig" rid="fig1">Figure 1</xref> ipsum dolor<xref id="xref-4" ref-type="fn" rid="fn1">1</xref> sit amet <xref id="xref-5" ref-type="bibr" rid="r1 r7">[1,2]</xref>.</p>
         <fig id="fig1">
           <label>Figure 1</label>
           <caption id="fig1-caption">
             <title>Behavioural design and implantation details.</title>
             <p id="fig1-caption-p1">Lorem ipsum dolor sit amet, ea ludus intellegat his, graece fastidii phaedrum ea mea, ne duo esse omnium.</p>
           </caption>
-          <graphic id="graphic-1" xmlns:xlink="http://www.w3.org/1999/xlink" mime-subtype="jpeg" mimetype="image" xlink:href="fig1.jpg" />
+          <graphic id="graphic-1" mime-subtype="jpeg" mimetype="image" xlink:href="fig1.jpg" />
           <permissions id="permission-2">
             <copyright-statement>© 2014 Surname et al.</copyright-statement>
             <copyright-year>2014</copyright-year>
@@ -230,7 +230,7 @@
             <title>Visual object processing in area AIP.</title>
             <p id="fig2-caption-p1" />
           </caption>
-          <graphic id="graphic-2" xmlns:xlink="http://www.w3.org/1999/xlink" mime-subtype="jpeg" mimetype="image" xlink:href="fig2.jpg" />
+          <graphic id="graphic-2" mime-subtype="jpeg" mimetype="image" xlink:href="fig2.jpg" />
         </fig>
         <disp-quote id="disp-quote-1">
           <p id="p-7">Curabitur vehicula mattis sodales. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
@@ -250,7 +250,7 @@ class Reader(fname: String) {
           <label>(1)</label>
           <tex-math><![CDATA[
 1+\frac{q^2}{(1-q)}+\frac{q^6}{(1-q)(1-q^2)}+\cdots=
-\prod_{j=0}^{\infty}\frac{1}{(1-q^{5j+2})(1-q^{5j+3})}, 
+\prod_{j=0}^{\infty}\frac{1}{(1-q^{5j+2})(1-q^{5j+3})},
 \quad\quad \text{for }\lvert q\rvert<1.]]></tex-math>
         </disp-formula>
         <list list-type="bullet" id="list-1">

--- a/data/kitchen-sink/manuscript.xml
+++ b/data/kitchen-sink/manuscript.xml
@@ -197,7 +197,7 @@
             </tr>
             <tr id="t1_4">
               <td id="t1_4_1">9</td>
-              <td id="t1_4_3">Hyper <ext-link  id="t1-ext-link-1" ext-link-type="uri" xlink:href="http://substance.io">link</ext-link> in table cell.</td>
+              <td id="t1_4_3">Hyper <ext-link id="t1-ext-link-1" ext-link-type="uri" xlink:href="http://substance.io">link</ext-link> in table cell.</td>
               <td id="t1_4_4">Reference citation in table cell <xref id="t1-xref-1" ref-type="bibr" rid="r7">[1]</xref></td>
             </tr>
           </tbody>

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "jsnext:main": "index.js",
   "dependencies": {
     "fs-extra": "^5.0.0",
-    "substance": "1.0.0-preview.104",
+    "substance": "1.0.0-preview.105",
     "yauzl": "^2.10.0",
     "yazl": "^2.4.3"
   },
   "peerDependency": {
-    "substance": "^1.0.0-preview.104"
+    "substance": "^1.0.0-preview.105"
   },
   "devDependencies": {
     "colors": "^1.3.2",

--- a/src/article/TableCellNode.js
+++ b/src/article/TableCellNode.js
@@ -1,4 +1,5 @@
 import { XMLTextElement } from 'substance'
+import { TEXT } from '../kit'
 
 export default class TableCellNode extends XMLTextElement {
   constructor (...args) {
@@ -26,6 +27,10 @@ export default class TableCellNode extends XMLTextElement {
 }
 
 TableCellNode.type = 'table-cell'
+
+TableCellNode.schema = {
+  content: TEXT('bold', 'italic', 'sup', 'sub', 'monospace', 'ext-link', 'xref', 'inline-formula')
+}
 
 function _parseSpan (str) {
   let span = parseInt(str, 10)

--- a/src/article/TableCellNode.js
+++ b/src/article/TableCellNode.js
@@ -29,7 +29,7 @@ export default class TableCellNode extends XMLTextElement {
 TableCellNode.type = 'table-cell'
 
 TableCellNode.schema = {
-  content: TEXT('bold', 'italic', 'sup', 'sub', 'monospace', 'ext-link', 'xref', 'inline-formula')
+  content: TEXT('bold', 'italic', 'sup', 'sub', 'monospace', 'ext-link', 'xref', 'inline-formula', 'inline-graphic')
 }
 
 function _parseSpan (str) {

--- a/src/article/converter/r2t/TableConverter.js
+++ b/src/article/converter/r2t/TableConverter.js
@@ -82,7 +82,7 @@ export default class TableConverter {
           }
         }
         el.attr(attributes)
-        el.setInnerXML(cell.getInnerXML())
+        el.append(exporter.annotatedText(cell.getPath()))
         tr.append(el)
       }
       tbody.append(tr)

--- a/src/article/converter/r2t/TableConverter.js
+++ b/src/article/converter/r2t/TableConverter.js
@@ -13,6 +13,8 @@ export default class TableConverter {
         children: []
       }
     })
+    // ATTENTION: this code is not 'idiomatic' as it does not delegate to converters for children elements
+    // and instead creates document nodes on the fly
     for (let i = 0; i < rows.length; i++) {
       let tr = rows[i]
       let newRow = newRows[i]
@@ -42,7 +44,11 @@ export default class TableConverter {
         _fillSpanned($$, newRows, i, k, rowspan, colspan)
         let cell = $$('table-cell', { id: c.id })
         cell.attr(attributes)
-        cell.content = importer.annotatedText(c, cell.getPath())
+        // ATTENTION: do not use 'cell.content = ...' here
+        // because this does not trigger an operation
+        // when this converter is used inside a transaction, the assigment does not have an effect
+        // TODO: In importers we should never assign directly but use a node.set('name', value)
+        cell.setText(importer.annotatedText(c, cell.getPath()))
         newRows[i].children[k] = cell
       }
     }

--- a/src/kit/ui/_TextPropertyEditor.js
+++ b/src/kit/ui/_TextPropertyEditor.js
@@ -23,6 +23,10 @@ export default class TextPropertyEditorNew extends ModifiedSurface(SubstanceText
 
   render ($$) {
     let el = super.render($$)
+
+    // We have added these improvements:
+    // - editable vs read-only
+    // - disabling contenteditable in read-only mode
     if (this.isEditable()) {
       el.addClass('sm-editable')
     } else {

--- a/test/ManuscriptEditor.test.js
+++ b/test/ManuscriptEditor.test.js
@@ -268,3 +268,81 @@ test('ManuscriptEditor: toggling a list', t => {
 
   t.end()
 })
+
+const SIMPLE_TABLE = `<table-wrap>
+  <table>
+    <tbody>
+      <tr>
+        <td id="t11">aaa</td>
+        <td id="t12">bbb</td>
+        <td id="t13">ccc</td>
+      </tr>
+      <tr>
+        <td id="t21">ddd</td>
+        <td id="t22">eee</td>
+        <td id="t23">fff</td>
+      </tr>
+      <tr>
+        <td id="t31">ggg</td>
+        <td id="t32">hhh</td>
+        <td id="t33">iii</td>
+      </tr>
+    </tbody>
+  </table>
+</table-wrap>`
+
+test('ManuscriptEditor: formatting in table cells', t => {
+  let { app } = setupTestApp(t, { archiveId: 'blank' })
+  let editor = openManuscriptEditor(app)
+  let doc = getDocument(editor)
+  loadBodyFixture(editor, SIMPLE_TABLE)
+
+  // use bold tool
+  setSelection(editor, 't11.content', 1, 2)
+  let boldTool = editor.find('.sc-toggle-tool.sm-bold')
+  // click on list tool to turn "p1" into a list
+  boldTool.find('button').el.click()
+  let annos = doc.getAnnotations(['t11', 'content'])
+  t.deepEqual(annos.map(a => a.type), ['bold'], 'there should be one bold annotation on t11')
+
+  // use italic tool
+  setSelection(editor, 't12.content', 1, 2)
+  let italicTool = editor.find('.sc-toggle-tool.sm-italic')
+  // click on list tool to turn "p1" into a list
+  italicTool.find('button').el.click()
+  annos = doc.getAnnotations(['t12', 'content'])
+  t.deepEqual(annos.map(a => a.type), ['italic'], 'there should be one italic annotation on t12')
+
+  // use sup tool
+  setSelection(editor, 't13.content', 1, 2)
+  let supTool = editor.find('.sc-toggle-tool.sm-sup')
+  // click on list tool to turn "p1" into a list
+  supTool.find('button').el.click()
+  annos = doc.getAnnotations(['t13', 'content'])
+  t.deepEqual(annos.map(a => a.type), ['sup'], 'there should be one sup annotation on t13')
+
+  // use sub tool
+  setSelection(editor, 't21.content', 1, 2)
+  let subTool = editor.find('.sc-toggle-tool.sm-sub')
+  // click on list tool to turn "p1" into a list
+  subTool.find('button').el.click()
+  annos = doc.getAnnotations(['t21', 'content'])
+  t.deepEqual(annos.map(a => a.type), ['sub'], 'there should be one sub annotation on t21')
+
+  // use monospace tool
+  setSelection(editor, 't22.content', 1, 2)
+  let monospaceTool = editor.find('.sc-toggle-tool.sm-monospace')
+  // click on list tool to turn "p1" into a list
+  monospaceTool.find('button').el.click()
+  annos = doc.getAnnotations(['t22', 'content'])
+  t.deepEqual(annos.map(a => a.type), ['monospace'], 'there should be one monospace annotation on t22')
+
+  t.end()
+})
+
+// TODO: add tests for table cells
+// - add ext-link
+// - cite figure
+// - cite table
+// - cite table-footnotes
+// - cite reference

--- a/test/Table.test.js
+++ b/test/Table.test.js
@@ -6,7 +6,7 @@ import {
 import { getMountPoint, DOMEvent } from './shared/testHelpers'
 import setupTestArticleSession from './shared/setupTestArticleSession'
 
-test('TableComponent: mounting a table component', t => {
+test('Table: mounting a table component', t => {
   let { table, context } = _setup(t)
   let el = getMountPoint(t)
   let comp = new TableComponent(null, { node: table }, { context })
@@ -15,7 +15,7 @@ test('TableComponent: mounting a table component', t => {
   t.end()
 })
 
-test('TableComponent: setting table selections', t => {
+test('Table: setting table selections', t => {
   let { editorSession, table, context } = _setup(t)
   let el = getMountPoint(t)
   let comp = new TableComponent(null, { node: table }, { context })
@@ -50,7 +50,7 @@ test('TableComponent: setting table selections', t => {
   t.end()
 })
 
-test('TableComponent: mouse interactions', t => {
+test('Table: mouse interactions', t => {
   let { editorSession, table, context } = _setup(t)
   let el = getMountPoint(t)
   let comp = new TableComponent(null, { node: table }, { context })
@@ -82,7 +82,7 @@ test('TableComponent: mouse interactions', t => {
   t.end()
 })
 
-test('TableComponent: keyboard interactions', t => {
+test('Table: keyboard interactions', t => {
   let { editorSession, table, context } = _setup(t)
   let el = getMountPoint(t)
   let comp = new TableComponent(null, { node: table }, { context })

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ import './ManuscriptEditor.test'
 import './MetadataEditor.test'
 import './Paste.test'
 import './Persistence.test'
-import './TableComponent.test'
+import './Table.test'
 import './TableConverter.test'
 import './BodyConverter.test'
 


### PR DESCRIPTION
## Why
At the moment it is not possible to format table cell content or add hyperlinks or citations. See #970.
This is also required for #111 .

 ## What

- Upgrades substance to a version which resolves an issue in TextPropertyEditor
- Changes the internal model to allow for various annotations and inline nodes
- Adds examples for formatting and inline nodes to kitchen-sink