### PR TITLE
Enable xrefs in Figure and Table  title

### DIFF
--- a/src/article/InternalArticleSchema.js
+++ b/src/article/InternalArticleSchema.js
@@ -111,7 +111,7 @@ class Figure extends DocumentNode {
 Figure.schema = {
   type: 'figure',
   content: CHILD('graphic'),
-  title: TEXT(...RICH_TEXT_ANNOS),
+  title: TEXT(...RICH_TEXT_ANNOS, 'xref'),
   label: STRING,
   caption: CHILD('caption'),
   permission: CHILD('permission')

--- a/test/Footnote.test.js
+++ b/test/Footnote.test.js
@@ -200,69 +200,40 @@ test('Footnotes: remove a table footnote', t => {
 })
 
 test('Footnotes: reference a footnote from a paragraph in the manuscript body', t => {
-  let { app } = setupTestApp(t, fixture('cross-references'))
-  let editor = openManuscriptEditor(app)
-  let doc = getDocument(editor)
-  setSelection(editor, 'p-0.content', 1)
-  _insertCrossRef(editor, 'fn', 'fn-1')
-  let p0 = doc.get('p-0')
-  let annos = p0.getAnnotations()
-  let xref = annos[0]
-  if (xref) {
-    let actual = {
-      type: xref.type,
-      refType: xref.getAttribute('ref-type'),
-      rid: xref.getAttribute('rid')
-    }
-    let expected = {
-      type: 'xref',
-      refType: 'fn',
-      rid: 'fn-1'
-    }
-    t.deepEqual(actual, expected, 'a xref to fn-1 should have been created')
-    t.equal(getLabel(xref), '1', 'label should be correct')
-  } else {
-    t.fail('xref has not been created')
-  }
-  t.end()
+  _testInsertXref(t, ['p-0', 'content'], 'fn', 'fn', 'fn-1', '1')
 })
 
 test('Footnotes: reference a footnote from a table-cell', t => {
-  let { app } = setupTestApp(t, fixture('cross-references'))
-  let editor = openManuscriptEditor(app)
-  let doc = getDocument(editor)
-  setSelection(editor, 't-1_2_1.content', 1)
-  _insertCrossRef(editor, 'fn', 'table-1-fn-1')
-  let td = doc.get('t-1_2_1')
-  let annos = td.getAnnotations()
-  let xref = annos[0]
-  if (xref) {
-    let actual = {
-      type: xref.type,
-      refType: xref.getAttribute('ref-type'),
-      rid: xref.getAttribute('rid')
-    }
-    let expected = {
-      type: 'xref',
-      refType: 'table-fn',
-      rid: 'table-1-fn-1'
-    }
-    t.deepEqual(actual, expected, 'a xref to table-1-fn-1 should have been created')
-    t.equal(getLabel(xref), '*', 'label should be correct')
-  } else {
-    t.fail('xref has not been created')
-  }
-  t.end()
+  _testInsertXref(t, ['t-1_2_1', 'content'], 'fn', 'table-fn', 'table-1-fn-1', '*')
 })
 
 test('Footnotes: reference a footnote from a table caption', t => {
+  _testInsertXref(t, ['table-1-caption-p-1', 'content'], 'fn', 'table-fn', 'table-1-fn-1', '*')
+})
+
+test('Footnotes: add a reference citation to a paragraph in the body', t => {
+  _testInsertXref(t, ['p-0', 'content'], 'bibr', 'bibr', 'r-1', '[1]')
+})
+
+test('Footnotes: add a reference citation into a table title', t => {
+  _testInsertXref(t, ['table-1', 'title'], 'bibr', 'bibr', 'r-1', '[1]')
+})
+
+test('Footnotes: add a reference citation into a table caption', t => {
+  _testInsertXref(t, ['table-1-caption-p-1', 'content'], 'bibr', 'bibr', 'r-1', '[1]')
+})
+
+test('Footnotes: add a reference citation into a table cell', t => {
+  _testInsertXref(t, ['t-1_2_1', 'content'], 'bibr', 'bibr', 'r-1', '[1]')
+})
+
+function _testInsertXref (t, path, refTool, refType, rid, label) {
   let { app } = setupTestApp(t, fixture('cross-references'))
   let editor = openManuscriptEditor(app)
   let doc = getDocument(editor)
-  setSelection(editor, 'table-1-caption-p-1.content', 1)
-  _insertCrossRef(editor, 'fn', 'table-1-fn-1')
-  let p = doc.get('table-1-caption-p-1')
-  let annos = p.getAnnotations()
+  setSelection(editor, path, 1)
+  _insertCrossRef(editor, refTool, rid)
+  let annos = doc.getAnnotations(path)
   let xref = annos[0]
   if (xref) {
     let actual = {
@@ -272,16 +243,16 @@ test('Footnotes: reference a footnote from a table caption', t => {
     }
     let expected = {
       type: 'xref',
-      refType: 'table-fn',
-      rid: 'table-1-fn-1'
+      refType,
+      rid
     }
-    t.deepEqual(actual, expected, 'a xref to table-1-fn-1 should have been created')
-    t.equal(getLabel(xref), '*', 'label should be correct')
+    t.deepEqual(actual, expected, 'a xref should have been created')
+    t.equal(getLabel(xref), label, 'label should be correct')
   } else {
     t.fail('xref has not been created')
   }
   t.end()
-})
+}
 
 function _insertCrossRef (editor, refType, rid) {
   let citeMenu = editor.find('.sc-tool-dropdown.sm-cite')

--- a/test/fixture/cross-references/manuscript.xml
+++ b/test/fixture/cross-references/manuscript.xml
@@ -59,5 +59,56 @@
         <p id="fn-1-p-1">Lorem ipsum dolor sit amet.</p>
       </fn>
     </fn-group>
+    <ref-list>
+      <ref id="r-1">
+        <element-citation publication-type="article">
+          <year>2017</year>
+          <pub-id pub-id-type="doi">10.1101/102392</pub-id>
+          <person-group person-group-type="author">
+            <name>
+              <surname>Alasoo</surname>
+              <given-names>K</given-names>
+            </name>
+            <name>
+              <surname>Rodrigues</surname>
+              <given-names>J</given-names>
+            </name>
+            <name>
+              <surname>Mukhopadhyay</surname>
+              <given-names>S</given-names>
+            </name>
+            <name>
+              <surname>Knights</surname>
+              <given-names>AJ</given-names>
+            </name>
+            <name>
+              <surname>Mann</surname>
+              <given-names>AL</given-names>
+            </name>
+            <name>
+              <surname>Kundu</surname>
+              <given-names>K</given-names>
+            </name>
+            <collab>
+              <named-content content-type="name">HIPSCI Consortium</named-content>
+            </collab>
+            <name>
+              <surname>Hale</surname>
+              <given-names>C</given-names>
+            </name>
+            <name>
+              <surname>Dougan</surname>
+              <given-names>G</given-names>
+            </name>
+            <name>
+              <surname>Gaffney</surname>
+              <given-names>DJ</given-names>
+            </name>
+          </person-group>
+          <source>bioRxiv</source>
+          <article-title>Shared genetic effects on chromatin and gene expression reveal widespread enhancer priming in immune response</article-title>
+        </element-citation>
+      </ref>
+    </ref-list>
   </back>
 </article>


### PR DESCRIPTION
## Why

See #935 

## What

- Adapts the internal model to allow for xrefs
- Adds tests for creating reference citations 
