### PR TITLE
Fix update preview comp

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "jsnext:main": "index.js",
   "dependencies": {
     "fs-extra": "^5.0.0",
-    "substance": "1.0.0-preview.110",
+    "substance": "1.0.0-preview-111",
     "yauzl": "^2.10.0",
     "yazl": "^2.4.3"
   },
   "peerDependency": {
-    "substance": "^1.0.0-preview.110"
+    "substance": "^1.0.0-preview-111"
   },
   "devDependencies": {
     "colors": "^1.3.2",

--- a/src/article/metadata/InplaceRefContribEditor.js
+++ b/src/article/metadata/InplaceRefContribEditor.js
@@ -28,16 +28,16 @@ export default class InplaceRefContribEditor extends ValueComponent {
     let id = refContrib.id
     let givenNames = refContrib.getGivenNames()
     let name = refContrib.getName()
-    return $$(FormRowComponent).append(
+    return $$(FormRowComponent).attr('data-id', id).addClass('sm-ref-contrib').append(
       // TODO: it would be good to have a default factory for property editors
       $$(StringComponent, {
         label: this.getLabel(name.name),
         model: name.model
-      }),
+      }).addClass('sm-name'),
       $$(StringComponent, {
         label: this.getLabel(givenNames.name),
         model: givenNames.model
-      }),
+      }).addClass('sm-given-names'),
       // TODO: use icon provider
       $$('button').addClass('se-remove-value')
         .append($$(FontAwesomeIcon, {icon: 'fa-trash'}))

--- a/src/article/shared/ModelPreviewComponent.js
+++ b/src/article/shared/ModelPreviewComponent.js
@@ -1,6 +1,15 @@
-import { ModelComponent } from '../../kit'
+import { Component } from 'substance'
+import { ifNodeOrRelatedHasChanged } from './nodeHelpers'
 
-export default class ModelPreviewComponent extends ModelComponent {
+export default class ModelPreviewComponent extends Component {
+  didMount () {
+    this.context.appState.addObserver(['document'], this._onDocumentChange, this, { stage: 'render' })
+  }
+
+  dispose () {
+    this.context.appState.removeObserver(this)
+  }
+
   render ($$) {
     // TODO: rethink this. IMO rendering should not be part of the Article API
     // Either it could be part of the general Model API, i.e. model.previewHtml()
@@ -12,5 +21,9 @@ export default class ModelPreviewComponent extends ModelComponent {
       api.renderEntity(model)
     )
     return el
+  }
+
+  _onDocumentChange (change) {
+    ifNodeOrRelatedHasChanged(this.props.model._node, change, () => this.rerender())
   }
 }

--- a/src/article/shared/NodeModelComponent.js
+++ b/src/article/shared/NodeModelComponent.js
@@ -72,7 +72,7 @@ export default class NodeModelComponent extends Component {
           $$(FormRowComponent, {
             label,
             issues
-          }).append(
+          }).addClass(`sm-${property.name}`).append(
             $$(PropertyEditor, {
               label,
               model

--- a/src/article/shared/nodeHelpers.js
+++ b/src/article/shared/nodeHelpers.js
@@ -26,3 +26,22 @@ export function findParentByType (node, type) {
     parent = parent.getParent()
   }
 }
+
+export function ifNodeOrRelatedHasChanged (node, change, cb) {
+  let doc = node.getDocument()
+  let id = node.id
+  let hasChanged = change.updated[id]
+  if (!hasChanged) {
+    let relationships = doc.getIndex('relationships')
+    // TODO: this could probably be improved by only navigating updated nodes
+    let ids = Object.keys(change.updated)
+    for (let _id of ids) {
+      let related = relationships.get(_id)
+      if (related && related.has(id)) {
+        hasChanged = true
+        break
+      }
+    }
+  }
+  if (hasChanged) cb()
+}

--- a/src/kit/app/DocumentObserver.js
+++ b/src/kit/app/DocumentObserver.js
@@ -29,18 +29,9 @@ export default class DocumentObserver {
   // DocumentChange. We could try to consolidate and have just
   // one place where this information is derived
   _onDocumentChanged (change) {
-    const doc = this.doc
-    const index = doc.getIndex('relationships')
     let dirty = this.dirty
     Object.keys(change.updated).forEach(id => {
       dirty.add(id)
-      let related = index.get(id)
-      if (related) {
-        // console.log('Capturing change via relationship', related)
-        related.forEach(id => {
-          dirty.add(id)
-        })
-      }
     })
   }
 }

--- a/src/kit/ui/FormRowComponent.js
+++ b/src/kit/ui/FormRowComponent.js
@@ -12,7 +12,6 @@ export default class FormRowComponent extends Component {
 
     if (label) {
       const labelEl = $$('div').addClass('se-label').append(label)
-
       if (hasIssues) {
         // TODO: use issue.key and labelProvider here
         let tooltipText = issues.map(issue => issue.message).join(', ')
@@ -23,18 +22,14 @@ export default class FormRowComponent extends Component {
           )
         )
       }
-
       el.append(labelEl)
     }
-
     if (hasIssues) {
       el.addClass('sm-warning')
     }
-
     el.append(
       $$('div').addClass('se-editor').append(children)
     )
-
     return el
   }
 }

--- a/test/EditReference.test.js
+++ b/test/EditReference.test.js
@@ -1,0 +1,30 @@
+import { test } from 'substance-test'
+import setupTestApp from './shared/setupTestApp'
+import { openMetadataEditor, setSelection, insertText } from './shared/integrationTestHelpers'
+
+test(`EditReference: add and edit authors`, t => {
+  let { app } = setupTestApp(t, { archiveId: 'blank' })
+  let editor = openMetadataEditor(app)
+  _addReference(editor, 'journal-article-ref')
+  // get the  reference card
+  let card = editor.find('.sc-card.sm-journal-article-ref')
+  // add an author
+  card.find('.sm-authors .se-add-value').el.click()
+  let refContribEl = card.find('.sm-authors .sm-ref-contrib')
+  let refContribId = refContribEl.attr('data-id')
+  setSelection(editor, [refContribId, 'name'], 0)
+  insertText(editor, 'Doe')
+  setSelection(editor, [refContribId, 'givenNames'], 0)
+  insertText(editor, 'John')
+  // TODO: this is very style
+  let previewText = card.find('.sc-model-preview').text()
+  t.ok(previewText.search('Doe') > -1, 'preview should display surname of author')
+  t.end()
+})
+
+function _addReference (editor, bibrType) {
+  let menu = editor.find('.sc-tool-dropdown.sm-add')
+  menu.find('button').el.click()
+  menu.find(`.sc-menu-item.sm-add-reference`).el.click()
+  editor.find(`.sc-modal-dialog .se-add-reference .se-type.sm-${bibrType}`).click()
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import { platform } from 'substance'
+import { platform, substanceGlobals } from 'substance'
 import './shared/testGlobals'
 // tests
 import './AddEntity.test'
@@ -9,6 +9,7 @@ import './BodyConverter.test'
 import './Card.test'
 import './Citations.test'
 import './ClipboardNew.test'
+import './EditReference.test'
 import './Footnote.test'
 import './FormulaConverter.test'
 import './FindAndReplace.test'
@@ -27,6 +28,8 @@ import './TableConverter.test'
 platform.test = true
 
 if (platform.inNodeJS) {
+  substanceGlobals.DEBUG_RENDERING = false
+
   if (process.env.TEST) {
     const { test } = require('substance-test')
     let harness = test.getHarness()

--- a/test/shared/integrationTestHelpers.js
+++ b/test/shared/integrationTestHelpers.js
@@ -50,7 +50,8 @@ export function setSelection (editor, path, from, to) {
   })
 }
 
-export function insertText (editorSession, text) {
+export function insertText (editor, text) {
+  let editorSession = editor.context.editorSession
   editorSession.transaction(tx => {
     tx.insertText(text)
   })


### PR DESCRIPTION
## Why

See #877 and #881. 

## What

- Disables automatic re-rendering when a node registered via 'relationship' has changed
- Let instead ModelPreviewComponent rerender on relationship changes
- Fixes #877
- Fixes #881