### PR TITLE
Article Subtitle

### DIFF
--- a/data/kitchen-sink/manuscript.xml
+++ b/data/kitchen-sink/manuscript.xml
@@ -15,6 +15,7 @@
       </article-categories>
       <title-group>
         <article-title>Kitchen Sink</article-title>
+        <subtitle>A word processor for structured content</subtitle>
         <trans-title-group xml:lang="es">
           <trans-title id="trans-title-1">Objeto de visión a acción manual en <italic id="italic-1">cortezas parietales</italic>, premotoras y motoras de macaco</trans-title>
         </trans-title-group>

--- a/docs/TextureArticle.md
+++ b/docs/TextureArticle.md
@@ -252,7 +252,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<break>`
@@ -267,7 +267,7 @@ EMPTY
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, chapter-title, institution, label, part-title, subject, title, trans-title, xref
+article-title, chapter-title, institution, label, part-title, subject, subtitle, title, trans-title, xref
 </pre>
 
 ### `<caption>`
@@ -672,7 +672,7 @@ id, xml:base, ext-link-type, assigning-authority, specific-use, xml:lang, xlink:
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-aff, article-title, chapter-title, data-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, suffix, surname, td, th, title, trans-title, uri, version, xref
+aff, article-title, chapter-title, data-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, subtitle, suffix, surname, td, th, title, trans-title, uri, version, xref
 </pre>
 
 ### `<fax>`
@@ -732,7 +732,7 @@ id, xml:base, content-type, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<fn>`
@@ -882,7 +882,7 @@ tex-math
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, chapter-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, suffix, surname, td, th, title, trans-title, uri, version, xref
+article-title, chapter-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, subtitle, suffix, surname, td, th, title, trans-title, uri, version, xref
 </pre>
 
 ### `<inline-graphic>`
@@ -897,7 +897,7 @@ alt-text?
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, chapter-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, suffix, surname, td, th, title, trans-title, uri, version, xref
+article-title, chapter-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, subtitle, suffix, surname, td, th, title, trans-title, uri, version, xref
 </pre>
 
 ### `<institution>`
@@ -1002,7 +1002,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<kwd>`
@@ -1137,7 +1137,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<month>`
@@ -1197,7 +1197,7 @@ TEXT
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, chapter-title, collab, data-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, preformat, role, series, subject, suffix, surname, td, th, title, trans-title, uri, version, xref
+article-title, chapter-title, collab, data-title, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, preformat, role, series, subject, subtitle, suffix, surname, td, th, title, trans-title, uri, version, xref
 </pre>
 
 ### `<object-id>`
@@ -1227,7 +1227,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<p>`
@@ -1512,7 +1512,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<season>`
@@ -1602,7 +1602,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<string-date>`
@@ -1647,7 +1647,7 @@ id, xml:base, arrange, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<subj-group>`
@@ -1680,6 +1680,21 @@ id, xml:base, content-type
 subj-group
 </pre>
 
+### `<subtitle>`
+
+**Attributes**:
+<pre style="white-space:pre-wrap;">
+id, xml:base, content-type, specific-use, xml:lang
+</pre>
+**Contains**:
+<pre style="white-space:pre-wrap;">
+(TEXT|ext-link|inline-supplementary-material|bold|fixed-case|italic|monospace|overline|overline-start|overline-end|roman|sans-serif|sc|strike|underline|underline-start|underline-end|ruby|alternatives|inline-graphic|private-char|chem-struct|inline-formula|abbrev|milestone-end|milestone-start|named-content|styled-content|target|xref|sub|sup|break)*
+</pre>
+**This element may be contained in:**
+<pre style="white-space:pre-wrap;">
+title-group
+</pre>
+
 ### `<suffix>`
 
 **Attributes**:
@@ -1707,7 +1722,7 @@ id, xml:base, arrange, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<supplementary-material>`
@@ -1898,7 +1913,7 @@ id, xml:base
 </pre>
 **Contains**:
 <pre style="white-space:pre-wrap;">
-article-title,trans-title-group*
+article-title,subtitle?,trans-title-group*
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
@@ -1977,7 +1992,7 @@ id, xml:base, toggle, underline-style, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<uri>`
@@ -2037,7 +2052,7 @@ id, xml:base, ref-type, alt, rid, specific-use, xml:lang
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, chapter-title, collab, contrib, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, suffix, surname, td, th, title, trans-title, uri, version, xref
+article-title, chapter-title, collab, contrib, edition, email, ext-link, given-names, institution, label, license-p, p, part-title, patent, phone, prefix, role, series, subject, subtitle, suffix, surname, td, th, title, trans-title, uri, version, xref
 </pre>
 
 ### `<year>`
@@ -2171,7 +2186,6 @@ and explanations that help understanding the use-case.
 - string-conf
 - styled-content
 - sub-article
-- subtitle
 - supplement
 - table-count
 - table-wrap-group

--- a/src/article/TextureArticle.rng
+++ b/src/article/TextureArticle.rng
@@ -143,7 +143,6 @@
   <s:not-implemented name="std-organization"/>
   <s:not-implemented name="string-conf"/>
   <s:not-implemented name="styled-content"/>
-  <s:not-implemented name="subtitle"/>
   <s:not-implemented name="sub-article"/>
   <s:not-implemented name="supplement"/>
   <s:not-implemented name="table-count"/>
@@ -1262,6 +1261,9 @@
     <element name="title-group">
       <ref name="title-group-attlist"/>
       <ref name="article-title"/>
+      <optional>
+        <ref name="subtitle"/>
+      </optional>
       <zeroOrMore>
         <ref name="trans-title-group"/>
       </zeroOrMore>

--- a/src/article/converter/r2t/internal2jats.js
+++ b/src/article/converter/r2t/internal2jats.js
@@ -248,13 +248,21 @@ function _exportSubjects (jats, doc) {
 
 function _exportTitleGroup (jats, doc, jatsExporter) {
   let $$ = jats.$$
-  // ATTENTION: ATM only one, *the* title is supported
-  // Potentially there are sub-titles, and JATS even supports more titles beyond this (e.g. for special purposes)
+  // ATTENTION: ATM only title and subtitle is supported
+  // JATS supports more titles beyond this (e.g. for special purposes)
   const TITLE_PATH = ['article', 'title']
+  const SUBTITLE_PATH = ['article', 'subTitle']
   let titleGroupEl = $$('title-group')
   let articleTitle = $$('article-title')
   _exportAnnotatedText(jatsExporter, TITLE_PATH, articleTitle)
   titleGroupEl.append(articleTitle)
+
+  // Export subtitle if it's not empty
+  if (doc.get(SUBTITLE_PATH)) {
+    let articleSubTitle = $$('subtitle')
+    _exportAnnotatedText(jatsExporter, SUBTITLE_PATH, articleSubTitle)
+    titleGroupEl.append(articleSubTitle)
+  }
 
   // translations
   doc.resolve(['article', 'translations']).filter(translation => {

--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -73,6 +73,7 @@ export default function jats2internal (jats, options) {
 
   // content
   _populateTitle(doc, jats, jatsImporter)
+  _populateSubTitle(doc, jats, jatsImporter)
   _populateAbstract(doc, jats, jatsImporter)
   _populateBody(doc, jats, jatsImporter)
   _populateFootnotes(doc, jats, jatsImporter)
@@ -324,6 +325,14 @@ function _populateTitle (doc, jats, jatsImporter) {
     })
     translation.content = jatsImporter.annotatedText(transTitleEl, translation.getPath())
     documentHelpers.append(doc, ['article', 'translations'], translation.id)
+  }
+}
+
+function _populateSubTitle (doc, jats, jatsImporter) {
+  let article = doc.get('article')
+  let subTitleEl = jats.find('article > front > article-meta > title-group > subtitle')
+  if (subTitleEl) {
+    article.subTitle = jatsImporter.annotatedText(subTitleEl, ['article', 'subTitle'])
   }
 }
 

--- a/src/article/metadata/ArticleInformationSectionModel.js
+++ b/src/article/metadata/ArticleInformationSectionModel.js
@@ -6,6 +6,7 @@ export default class ArticleInformationSectionModel {
     const doc = api.getDocument()
     this.cards = [
       { name: 'title', model: createValueModel(api, ['article', 'title']) },
+      { name: 'subtitle', model: createValueModel(api, ['article', 'subTitle']) },
       { name: 'abstract', model: createValueModel(api, ['article', 'abstract']) },
       { name: 'article-metadata', model: { id: 'article-metadata', node: doc.get('metadata') } }
     ]

--- a/src/article/metadata/MetadataPackage.js
+++ b/src/article/metadata/MetadataPackage.js
@@ -162,6 +162,7 @@ export default {
     config.addLabel('enter-custom-field-name', 'Enter name')
     config.addLabel('enter-custom-field-value', 'Enter value')
     config.addLabel('article-metadata', 'Article Metadata')
+    config.addLabel('subtitle', 'Subtitle')
     // Icons
     config.addIcon('move-down-figure-panel', { 'fontawesome': 'fa-caret-square-o-down' })
 

--- a/src/article/models/Article.js
+++ b/src/article/models/Article.js
@@ -6,6 +6,7 @@ Article.schema = {
   type: 'article',
   metadata: CHILD('metadata'),
   title: TEXT(RICH_TEXT_ANNOS),
+  subTitle: TEXT(RICH_TEXT_ANNOS),
   abstract: CHILD('abstract'),
   body: CHILD('body'),
   references: CHILDREN('reference'),

--- a/src/article/models/ManuscriptModel.js
+++ b/src/article/models/ManuscriptModel.js
@@ -6,6 +6,7 @@ import { createValueModel } from '../../kit'
 export default class ManuscriptModel {
   constructor (api, doc) {
     this._title = createValueModel(api, ['article', 'title'])
+    this._subTitle = createValueModel(api, ['article', 'subTitle'])
     this._abstract = createValueModel(api, ['article', 'abstract'])
     this._authors = createValueModel(api, ['metadata', 'authors'])
     this._body = createValueModel(api, ['body', 'content'])
@@ -47,5 +48,9 @@ export default class ManuscriptModel {
 
   getTitle () {
     return this._title
+  }
+
+  getSubTitle () {
+    return this._subTitle
   }
 }

--- a/src/article/shared/ManuscriptComponent.js
+++ b/src/article/shared/ManuscriptComponent.js
@@ -11,7 +11,9 @@ export default class ManuscriptComponent extends Component {
 
     let el = $$('div').addClass('sc-manuscript').append(
       $$(SectionLabel, { label: 'title-label' }).addClass('sm-title'),
-      renderModel($$, this, manuscript.getTitle()).addClass('sm-title').ref('title')
+      renderModel($$, this, manuscript.getTitle(), {placeholder: 'title-placeholder'}).addClass('sm-title').ref('title'),
+      $$(SectionLabel, { label: 'subtitle-label' }).addClass('sm-subtitle'),
+      renderModel($$, this, manuscript.getSubTitle(), {placeholder: 'subtitle-placeholder'}).addClass('sm-subtitle').ref('subtitle')
     )
 
     // TODO: we need to think about a way to configure what should be displayed

--- a/src/article/shared/ManuscriptComponent.js
+++ b/src/article/shared/ManuscriptComponent.js
@@ -11,9 +11,13 @@ export default class ManuscriptComponent extends Component {
 
     let el = $$('div').addClass('sc-manuscript').append(
       $$(SectionLabel, { label: 'title-label' }).addClass('sm-title'),
-      renderModel($$, this, manuscript.getTitle(), {placeholder: 'title-placeholder'}).addClass('sm-title').ref('title'),
+      renderModel($$, this, manuscript.getTitle(), {
+        placeholder: this.getLabel('title-placeholder')
+      }).addClass('sm-title').ref('title'),
       $$(SectionLabel, { label: 'subtitle-label' }).addClass('sm-subtitle'),
-      renderModel($$, this, manuscript.getSubTitle(), {placeholder: 'subtitle-placeholder'}).addClass('sm-subtitle').ref('subtitle')
+      renderModel($$, this, manuscript.getSubTitle(), {
+        placeholder: this.getLabel('subtitle-placeholder')
+      }).addClass('sm-subtitle').ref('subtitle')
     )
 
     // TODO: we need to think about a way to configure what should be displayed

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -87,6 +87,8 @@ export default {
     config.addLabel('references-label', 'References')
     config.addLabel('title-label', 'Title')
     config.addLabel('title-placeholder', 'Enter title')
+    config.addLabel('subtitle-label', 'Subtitle')
+    config.addLabel('subtitle-placeholder', 'Enter subtitle')
 
     // Used for rendering warning in case of missing images
     config.addIcon('graphic-load-error', { 'fontawesome': 'fa-warning' })


### PR DESCRIPTION
## Why

In addition to the article title there is an extra field for the subtitle, we want to edit it from both manuscript and metadata views.

## What

This PR extends all necessarily changes according to implementation plan:
- [x] Extended kitchen-sink
- [x] Extended Article schema
- [x] Extended XML schema
- [x] Extended importer and export
- [x] Subtitle editor underneath Title in Manuscript View
- [x] Show Subtitle editor card in ‘Article Information’ section
