### PR TITLE
Download file improvements

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -40,7 +40,11 @@ app.on('ready', () => {
   // Download files
   session.defaultSession.on('will-download', (event, item) => {
     let location = dialog.showSaveDialog({ defaultPath: item.getFilename() })
-    item.setSavePath(location)
+    if (location) {
+      item.setSavePath(location)
+    } else {
+      event.preventDefault()
+    }
   })
 
   createMenu()

--- a/app/main.js
+++ b/app/main.js
@@ -5,7 +5,7 @@ const url = require('url')
 const fsExtra = require('fs-extra')
 
 const {
-  app, dialog, shell, protocol,
+  app, dialog, shell, protocol, session,
   BrowserWindow, Menu, ipcMain
 } = electron
 const DEBUG = process.env.DEBUG
@@ -35,6 +35,12 @@ app.on('ready', () => {
     }
   }, (error) => {
     if (error) console.error('Failed to register protocol')
+  })
+
+  // Download files
+  session.defaultSession.on('will-download', (event, item) => {
+    let location = dialog.showSaveDialog({ defaultPath: item.getFilename() })
+    item.setSavePath(location)
   })
 
   createMenu()

--- a/app/main.js
+++ b/app/main.js
@@ -40,6 +40,8 @@ app.on('ready', () => {
   // Download files
   session.defaultSession.on('will-download', (event, item) => {
     let location = dialog.showSaveDialog({ defaultPath: item.getFilename() })
+    // If there is no location came from dialog it means cancelation and
+    // we should prevent default action to close dialog without error
     if (location) {
       item.setSavePath(location)
     } else {

--- a/src/article/editor/DownloadSupplementaryFileCommand.js
+++ b/src/article/editor/DownloadSupplementaryFileCommand.js
@@ -6,14 +6,23 @@ import { Command } from 'substance'
 */
 export default class DownloadSupplementaryFileCommand extends Command {
   getCommandState (params, context) {
-    const xpath = params.selectionState.xpath
+    const selectionState = params.selectionState
+    const xpath = selectionState.xpath
     if (xpath.length > 0) {
       const selectedType = xpath[xpath.length - 1].type
-      return { disabled: selectedType !== 'supplementary-file' }
+      if (selectedType === 'supplementary-file') {
+        return {
+          disabled: false,
+          // leaving the node, so that the tool can apply different
+          // strategies for local vs remote files
+          node: selectionState.node
+        }
+      }
     }
     return { disabled: true }
   }
 
   execute (params, context) {
+    // Nothing: downloading is implemented via native download hooks
   }
 }

--- a/src/article/editor/DownloadSupplementaryFileTool.js
+++ b/src/article/editor/DownloadSupplementaryFileTool.js
@@ -5,10 +5,25 @@ export default class DownloadSupplementaryFileTool extends Tool {
   render ($$) {
     let el = super.render($$)
     let link = $$('a').ref('link')
-      // Downloads a non-remote urls
-      .attr('download', '')
       // ATTENTION: stop propagation, otherwise infinite loop
       .on('click', domHelpers.stop)
+
+    // Downloading is a bit involved:
+    // In electron, everything can be done with one solution,
+    // handling a 'will-download' event, which is triggered when the `download`
+    // attribute is present.
+    // For the browser, the `download` attribute works only for files from the same
+    // origin. For remote files the best we can do at the moment, is opening
+    // a new tab, and let the browser deal with it.
+    // TODO: if this feature is important, one idea is that the DAR server could
+    // provide an end-point to provide download-urls, and act as a proxy to
+    // cirvumvent the CORS problem.
+    const isLocal = this._isLocal()
+    if (platform.inElectron || isLocal) {
+      link.attr('download', '')
+    } else {
+      link.attr('target', '_blank')
+    }
 
     el.append(link)
     return el
@@ -26,10 +41,8 @@ export default class DownloadSupplementaryFileTool extends Tool {
 
   _triggerDownload () {
     const archive = this.context.archive
-    const editorSession = this.context.editorSession
-    const selectionState = editorSession.getSelectionState()
-    const node = selectionState.node
-    const isLocal = !node.remote
+    const node = this._getNode()
+    const isLocal = this._isLocal()
     let url = node.href
     if (isLocal) {
       url = archive.getDownloadLink(node.href)
@@ -38,11 +51,16 @@ export default class DownloadSupplementaryFileTool extends Tool {
       this.refs.link.el.attr({
         'href': url
       })
-      // Note: in the browser version we want to open remote files in a new tab
-      if (!platform.inElectron && !isLocal) {
-        this.refs.link.attr('target', '_blank')
-      }
       this.refs.link.el.click()
     }
+  }
+
+  _getNode () {
+    return this.props.commandState.node
+  }
+
+  _isLocal () {
+    let node = this._getNode()
+    return (!node || !node.remote)
   }
 }

--- a/src/article/editor/DownloadSupplementaryFileTool.js
+++ b/src/article/editor/DownloadSupplementaryFileTool.js
@@ -5,15 +5,11 @@ export default class DownloadSupplementaryFileTool extends Tool {
   render ($$) {
     let el = super.render($$)
     let link = $$('a').ref('link')
-      // Note: download attribute instructs browsers to download a URL instead of navigating to it
-      // but only for same-origin URLs, e.g. it will not work for remote images
+      // Downloads a non-remote urls
       .attr('download', '')
       // ATTENTION: stop propagation, otherwise infinite loop
       .on('click', domHelpers.stop)
-    // Note: in the browser version we want to open the download in a new tab
-    if (!platform.inElectron) {
-      link.attr('target', '_blank')
-    }
+
     el.append(link)
     return el
   }
@@ -42,6 +38,10 @@ export default class DownloadSupplementaryFileTool extends Tool {
       this.refs.link.el.attr({
         'href': url
       })
+      // Note: in the browser version we want to open remote files in a new tab
+      if (!platform.inElectron && !isLocal) {
+        this.refs.link.attr('target', '_blank')
+      }
       this.refs.link.el.click()
     }
   }

--- a/src/article/editor/DownloadSupplementaryFileTool.js
+++ b/src/article/editor/DownloadSupplementaryFileTool.js
@@ -5,6 +5,9 @@ export default class DownloadSupplementaryFileTool extends Tool {
   render ($$) {
     let el = super.render($$)
     let link = $$('a').ref('link')
+      // Note: download attribute instructs browsers to download a URL instead of navigating to it
+      // but only for same-origin URLs, e.g. it will not work for remote images
+      .attr('download', '')
       // ATTENTION: stop propagation, otherwise infinite loop
       .on('click', domHelpers.stop)
     // Note: in the browser version we want to open the download in a new tab


### PR DESCRIPTION
## Why

As discussed in #1132 we want to improve file downloading in both browser and electron versions.

## What

For browser version:
  local files with `@download`
  remote with new tab
For electron version:
  show file dialog for saving