### PR TITLE
Rich text keyword

### DIFF
--- a/docs/TextureArticle.md
+++ b/docs/TextureArticle.md
@@ -252,7 +252,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<break>`
@@ -732,7 +732,7 @@ id, xml:base, content-type, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<fn>`
@@ -1002,7 +1002,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<kwd>`
@@ -1013,7 +1013,7 @@ id, xml:base, content-type
 </pre>
 **Contains**:
 <pre style="white-space:pre-wrap;">
-TEXT
+(TEXT|bold|fixed-case|italic|monospace|overline|overline-start|overline-end|roman|sans-serif|sc|strike|underline|underline-start|underline-end|ruby|sub|sup)*
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
@@ -1137,7 +1137,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<month>`
@@ -1227,7 +1227,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<p>`
@@ -1512,7 +1512,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<season>`
@@ -1602,7 +1602,7 @@ id, xml:base, toggle, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<string-date>`
@@ -1647,7 +1647,7 @@ id, xml:base, arrange, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<subj-group>`
@@ -1722,7 +1722,7 @@ id, xml:base, arrange, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<supplementary-material>`
@@ -1992,7 +1992,7 @@ id, xml:base, toggle, underline-style, specific-use
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
+article-title, attrib, bold, chapter-title, data-title, edition, email, ext-link, fixed-case, given-names, institution, issue-title, italic, kwd, label, license-p, monospace, named-content, overline, p, part-title, patent, phone, prefix, preformat, price, role, sc, series, source, strike, string-name, sub, subject, subtitle, suffix, sup, surname, td, th, title, trans-title, underline, uri, version, xref
 </pre>
 
 ### `<uri>`

--- a/src/article/TextureArticle.rng
+++ b/src/article/TextureArticle.rng
@@ -886,7 +886,12 @@
   <define name="kwd">
     <element name="kwd">
       <ref name="kwd-attlist"/>
-      <text/>
+      <zeroOrMore>
+        <choice>
+          <text/>
+          <ref name="rich-text"/>
+        </choice>
+      </zeroOrMore>
     </element>
   </define>
 

--- a/src/article/converter/r2t/internal2jats.js
+++ b/src/article/converter/r2t/internal2jats.js
@@ -193,7 +193,7 @@ function _populateArticleMeta (jats, doc, jatsExporter) {
 
   // kwd-group*,
   articleMeta.append(
-    _exportKeywords(jats, doc)
+    _exportKeywords(jats, doc, jatsExporter)
   )
 
   // funding-group*,
@@ -551,7 +551,7 @@ function _exportAbstract (jats, doc, jatsExporter) {
   return els
 }
 
-function _exportKeywords (jats, doc) {
+function _exportKeywords (jats, doc, jatsExporter) {
   const $$ = jats.$$
   // TODO: keywords should be translatables
   const keywords = doc.resolve(['metadata', 'keywords'])
@@ -568,7 +568,9 @@ function _exportKeywords (jats, doc) {
     let groupEl = $$('kwd-group').attr('xml:lang', lang)
     groupEl.append(
       keywords.map(keyword => {
-        return $$('kwd').attr({ 'content-type': keyword.category }).text(keyword.name)
+        return $$('kwd').attr({ 'content-type': keyword.category }).append(
+          jatsExporter.annotatedText([keyword.id, 'name'])
+        )
       })
     )
     keywordGroups.push(groupEl)

--- a/src/article/converter/r2t/jats2internal.js
+++ b/src/article/converter/r2t/jats2internal.js
@@ -68,7 +68,7 @@ export default function jats2internal (jats, options) {
   _populateEditors(doc, jats, jatsImporter)
   _populateFunders(doc, jats)
   _populateArticleInfo(doc, jats, jatsImporter)
-  _populateKeywords(doc, jats)
+  _populateKeywords(doc, jats, jatsImporter)
   _populateSubjects(doc, jats)
 
   // content
@@ -271,15 +271,16 @@ function _extractDate (el) {
   }
 }
 
-function _populateKeywords (doc, jats) {
+function _populateKeywords (doc, jats, jatsImporter) {
   let kwdEls = jats.findAll('article > front > article-meta > kwd-group > kwd')
   let kwdIds = kwdEls.map(kwdEl => {
-    return doc.create({
+    const kwd = doc.create({
       type: 'keyword',
-      name: kwdEl.textContent,
       category: kwdEl.getAttribute('content-type'),
       language: kwdEl.getParent().getAttribute('xml:lang')
-    }).id
+    })
+    kwd.name = jatsImporter.annotatedText(kwdEl, [kwd.id, 'name'])
+    return kwd.id
   })
   doc.get('metadata').keywords = kwdIds
 }

--- a/src/article/models/Keyword.js
+++ b/src/article/models/Keyword.js
@@ -1,9 +1,10 @@
-import { DocumentNode, STRING } from 'substance'
+import { DocumentNode, STRING, TEXT } from 'substance'
+import { RICH_TEXT_ANNOS } from './modelConstants'
 
 export default class Keyword extends DocumentNode {}
 Keyword.schema = {
   type: 'keyword',
-  name: STRING,
+  name: TEXT(...RICH_TEXT_ANNOS),
   category: STRING,
   language: STRING
 }


### PR DESCRIPTION
## Why

As there was requested in #990 keywords should allow italics. However for the sake of consistency we decided to allow full set of annotations: bold, italic, superscript, subscript.

## What

This PR contains necessary changes to schema and importers/exporters.