### PR TITLE
Sub figure templates

### DIFF
--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -480,10 +480,14 @@ export default class ArticleAPI {
     const pos = figure.getCurrentPanelIndex()
     const href = this.archive.addAsset(file)
     const insertPos = pos + 1
+    // NOTE: with this method we are getting the structure of the first panel
+    // to replicate it, currently only for metadata fields
+    const panelTemplate = figure.getPanelTemplate()
     this.editorSession.transaction(tx => {
       let template = FigurePanel.getTemplate()
       template.content.href = href
       template.content.mimeType = file.type
+      Object.assign(template, panelTemplate)
       let node = documentHelpers.createNodeFromJson(tx, template)
       documentHelpers.insertAt(tx, [figure.id, 'panels'], insertPos, node.id)
       tx.set([figure.id, 'state', 'currentPanelIndex'], insertPos)

--- a/src/article/ArticleAPI.js
+++ b/src/article/ArticleAPI.js
@@ -480,9 +480,9 @@ export default class ArticleAPI {
     const pos = figure.getCurrentPanelIndex()
     const href = this.archive.addAsset(file)
     const insertPos = pos + 1
-    // NOTE: with this method we are getting the structure of the first panel
+    // NOTE: with this method we are getting the structure of the active panel
     // to replicate it, currently only for metadata fields
-    const panelTemplate = figure.getPanelTemplate()
+    const panelTemplate = figure.getTemplateFromCurrentPanel()
     this.editorSession.transaction(tx => {
       let template = FigurePanel.getTemplate()
       template.content.href = href

--- a/src/article/models/Figure.js
+++ b/src/article/models/Figure.js
@@ -20,6 +20,17 @@ export default class Figure extends DocumentNode {
   getPanels () {
     return this.resolve('panels')
   }
+
+  // NOTE: we are using structure of first panel as template for new one,
+  // currently we are replicating the structure of metadata fields
+  getPanelTemplate () {
+    const firstPanel = this.getPanels()[0]
+    return {
+      metadata: firstPanel.resolve('metadata').map(metadataField => (
+        { type: 'custom-metadata-field', name: metadataField.name, value: '' }
+      ))
+    }
+  }
 }
 Figure.schema = {
   type: 'figure',

--- a/src/article/models/Figure.js
+++ b/src/article/models/Figure.js
@@ -21,10 +21,11 @@ export default class Figure extends DocumentNode {
     return this.resolve('panels')
   }
 
-  // NOTE: we are using structure of first panel as template for new one,
+  // NOTE: we are using structure of active panel as template for new one,
   // currently we are replicating the structure of metadata fields
-  getPanelTemplate () {
-    const firstPanel = this.getPanels()[0]
+  getTemplateFromCurrentPanel () {
+    const currentIndex = this.getCurrentPanelIndex()
+    const firstPanel = this.getPanels()[currentIndex]
     return {
       metadata: firstPanel.resolve('metadata').map(metadataField => (
         { type: 'custom-metadata-field', name: metadataField.name, value: '' }

--- a/test/Figure.test.js
+++ b/test/Figure.test.js
@@ -24,6 +24,7 @@ const xrefListItemSelector = '.sc-edit-xref-tool .se-option .sc-preview'
 const figurePanelPreviousSelector = '.sc-figure .se-control.sm-previous'
 const figurePanelNextSelector = '.sc-figure .se-control.sm-next'
 const currentPanelSelector = '.sc-figure .se-current-panel .sc-figure-panel'
+const figureCustomMetadataFieldInputSelector = '.sc-custom-metadata-field .sc-string'
 
 const FIGURE_WITH_TWO_PANELS = `
 <fig-group id="fig1">
@@ -432,6 +433,38 @@ test('Figure: remove and move figure panels in metadata view', t => {
   t.equal(getSubFigureId(cards[0]), 'fig1c', 'first card should be the moved one')
   t.equal(getSubFigureLabel(cards[0]), 'Figure 1A', 'sub-figure label should have been updated')
   t.notOk(isMoveUpPossible(), 'move up sub-figure tool should be unavailable')
+  t.end()
+})
+
+const FIGURE_PANEL_WITH_CUSTOM_FIELDS = `
+  <fig-group id="fig1">
+    <fig id="fig1a">
+      <graphic />
+      <caption>
+        <p id="fig1a-caption-p1"></p>
+      </caption>
+      <kwd-group>
+        <label>Field I</label>
+        <kwd>Value A</kwd>
+        <kwd>Value B</kwd>
+      </kwd-group>
+    </fig>
+  </fig-group>
+`
+
+test('Figure: replicate first panel structure', t => {
+  let { app } = setupTestApp(t, { archiveId: 'blank' })
+  let editor = openManuscriptEditor(app)
+  const _gotoNext = () => editor.find(figurePanelNextSelector).el.click()
+  loadBodyFixture(editor, FIGURE_PANEL_WITH_CUSTOM_FIELDS)
+  selectNode(editor, 'fig1')
+  const insertFigurePanelTool = openMenuAndFindTool(editor, 'figure-tools', insertFigurePanelSelector)
+  t.ok(insertFigurePanelTool.el.click(), 'clicking on the insert figure panel button should not throw error')
+  insertFigurePanelTool.onFileSelect(new PseudoFileEvent())
+  _gotoNext()
+  const fields = editor.findAll(figureCustomMetadataFieldInputSelector)
+  t.equal(fields[0].getTextContent(), 'Field I', 'shoud be replicated keyword label inside custom field name')
+  t.equal(fields[1].getTextContent(), '', 'shoud be empty value')
   t.end()
 })
 


### PR DESCRIPTION
As it was described in #1163 we wanted to be able to replicate structure of sub-figures using first as template.

This PR contains the implementation of replication, but only for metadata fields. Potentially it could be easily expanded to other fields.