### PR TITLE
Issue 1214

### DIFF
--- a/src/dar/FSStorage.js
+++ b/src/dar/FSStorage.js
@@ -1,13 +1,14 @@
-/* global FileReader, Buffer */
+/* global Buffer */
 import { platform } from 'substance'
 import readArchive from './readArchive'
 import writeArchive from './writeArchive'
 import cloneArchive from './cloneArchive'
 
 // FIXME: this file should only get bundled in commonjs version
-let path
+let path, fs
 if (platform.inNodeJS || platform.inElectron) {
   path = require('path')
+  fs = require('fs')
 }
 
 /*
@@ -79,20 +80,8 @@ async function _convertBlobs (rawArchive) {
   for (var i = 0; i < paths.length; i++) {
     let record = resources[paths[i]]
     if (record.encoding === 'blob') {
-      record.data = await _blobToArrayBuffer(record.data)
+      // TODO: is there other way to get buffer out of Blob without browser APIs?
+      record.data = fs.readFileSync(record.data.path)
     }
   }
-}
-
-function _blobToArrayBuffer (blob) {
-  return new Promise(resolve => {
-    let reader = new FileReader()
-    reader.onload = function () {
-      if (reader.readyState === 2) {
-        var buffer = Buffer.from(reader.result)
-        resolve(buffer)
-      }
-    }
-    reader.readAsArrayBuffer(blob)
-  })
 }

--- a/src/dar/FSStorage.js
+++ b/src/dar/FSStorage.js
@@ -5,10 +5,10 @@ import writeArchive from './writeArchive'
 import cloneArchive from './cloneArchive'
 
 // FIXME: this file should only get bundled in commonjs version
-let path, fs
+let fs, path
 if (platform.inNodeJS || platform.inElectron) {
-  path = require('path')
   fs = require('fs')
+  path = require('path')
 }
 
 /*
@@ -80,8 +80,17 @@ async function _convertBlobs (rawArchive) {
   for (var i = 0; i < paths.length; i++) {
     let record = resources[paths[i]]
     if (record.encoding === 'blob') {
-      // TODO: is there other way to get buffer out of Blob without browser APIs?
-      record.data = fs.readFileSync(record.data.path)
+      record.data = await _blobToArrayBuffer(record.data)
     }
   }
+}
+
+function _blobToArrayBuffer (blob) {
+  return new Promise((resolve, reject) => {
+    // TODO: is there other way to get buffer out of Blob without browser APIs?
+    fs.readFile(blob.path, (err, buffer) => {
+      if (err) return reject(err)
+      resolve(buffer)
+    })
+  })
 }


### PR DESCRIPTION
As it was reported in #1214, the app can't save document after figure insertion.
This is regression from #1164. FSStorage which is now used only inside node.js via electron RPC calls was calling browser FileReader during Blob -> Array buffer conversion.
For now we will just read file via classical fs.readFile method.
