### PR TITLE
Opt-in Routing

### DIFF
--- a/builds/demo/demo.js
+++ b/builds/demo/demo.js
@@ -12,7 +12,8 @@ window.addEventListener('load', () => {
       archiveId: getQueryStringParam('archive') || 'kitchen-sink',
       storageType: getQueryStringParam('storage') || 'vfs',
       storageUrl: getQueryStringParam('storageUrl') || '/archives',
-      vfs: window.vfs
+      vfs: window.vfs,
+      enableRouting: true
     }, window.document.body)
 
     // put the archive and some more things into global scope, for debugging

--- a/src/TextureAppChrome.js
+++ b/src/TextureAppChrome.js
@@ -6,7 +6,10 @@ export default class TextureAppChrome extends Component {
   constructor (...args) {
     super(...args)
 
-    this._router = new Router()
+    if (this.props.enableRouting) {
+      this._router = new Router()
+    }
+
     // TODO: rethink how configuration is loaded
     this._config = Texture.getConfiguration()
   }
@@ -40,7 +43,9 @@ export default class TextureAppChrome extends Component {
       DefaultDOMElement.getBrowserWindow().on('drop', domHelpers.stopAndPrevent, this)
       DefaultDOMElement.getBrowserWindow().on('dragover', domHelpers.stopAndPrevent, this)
     }
-    this._router.start()
+    if (this._router) {
+      this._router.start()
+    }
     this.handleActions({
       'save': this._handleSave
     })

--- a/src/article/ArticlePanel.js
+++ b/src/article/ArticlePanel.js
@@ -237,8 +237,10 @@ export default class ArticlePanel extends Component {
 
   // Routing
   // =======
-  // NOTE: I don't thing that this is generally a good idea. E.g. what to do if multiple this is embedded
-  // into a different thing with its own router.
+  // ATTENTION: routing is a questionable feature, because Texture might be embedded into an environment with
+  // its own routing. We primarily use it for development. We are considering to remove it from this component
+  // and instead do this just in the demo setup.
+  // ATM, this is only activated when Texture is mounted with `enableRouting:true`
 
   _clearRoute () {
     let router = this.context.router


### PR DESCRIPTION
## Why

When embedding Texture, the built-in routing may interfer with the application.

## What

This PR changes the default behavior to disable routing.