### PR TITLE
Add releases and roadmap links and context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Texture is a toolset designed for the production of scientific content. It uses 
 
 Feature requests can be made via the GitHub issues using a Feature request template. It will be assessed and costed, then scheduled accordingly in collaboration with the requesting organisation. Please feedback any problems with the product using the Bug template.
 
+## Releases and Roadmap
+
+[The current release](https://github.com/substance/texture/releases/) is *Texture 2.3*, released 12 April 2019. Texture is currently in beta and optimised for publishers. An updated version will add missing features to fully support scientific authoring.
+
+See [the Roadmap section of the Product Brief](https://docs.google.com/document/d/1ZOjKrQZOndU9G12bVaXmFt56aWRW4kJSDjaMjcxSHSc/edit#heading=h.gsyknu9gn8x).
+
 ## Install
 
 *You need Node 8.x installed on your system.*


### PR DESCRIPTION
## Why

Previous commits https://github.com/substance/texture/commit/cbebe0954dccf08d74af0fed25749933ed002da2#diff-04c6e90faac2675aa89e2176d2eec7d8 , https://github.com/substance/texture/commit/18c55b9cc63d2915d5b318162fdf9a63bda5bfe6#diff-04c6e90faac2675aa89e2176d2eec7d8 , and https://github.com/substance/texture/commit/cf1375638b7f3abd1163a6f8c5174bc5adaa6129#diff-04c6e90faac2675aa89e2176d2eec7d8 replaced the tabular roadmap with a link to the Product Brief roadmap, then removed that link. Interested potential users would like to know when we can expect the improvements discussed in [the May eLife article](https://elifesciences.org/labs/8de87c33/texture-an-open-science-manuscript-editor) and [the update from 2017](https://elifesciences.org/labs/8de87c33/texture-an-open-science-manuscript-editor), and easily find out when the project published its most recent release.

## What

I added contextual information from [the official Texture webpage](https://substance.io/texture/) and linked to the roadmap section of the Product Brief document.
