### PR TITLE
add issn field

### DIFF
--- a/src/article/converter/bib/BibConversion.js
+++ b/src/article/converter/bib/BibConversion.js
@@ -82,6 +82,7 @@ function _convertFromCSLJSON (source, type) {
     confName: source.event,
     confLoc: source['event-place'],
     isbn: source.ISBN,
+    issn: source.ISSN,
 
     year: date.year,
     month: date.month,

--- a/src/article/converter/jats/ElementCitationConverter.js
+++ b/src/article/converter/jats/ElementCitationConverter.js
@@ -65,6 +65,7 @@ function _importElementCitation (el, node, doc, importer) {
     archiveId: getText(el, 'pub-id[pub-id-type=archive]'),
     arkId: getText(el, 'pub-id[pub-id-type=ark]'),
     isbn: getText(el, 'pub-id[pub-id-type=isbn]'),
+    issn: getText(el, 'pub-id[pub-id-type=issn]'),
     doi: getText(el, 'pub-id[pub-id-type=doi]'),
     pmid: getText(el, 'pub-id[pub-id-type=pmid]')
   })
@@ -168,6 +169,7 @@ function _exportElementCitation (node, exporter) {
   el.append(_createTextElement($$, node.arkId, 'pub-id', { 'pub-id-type': 'ark' }))
   el.append(_createTextElement($$, node.archiveId, 'pub-id', { 'pub-id-type': 'archive' }))
   el.append(_createTextElement($$, node.isbn, 'pub-id', { 'pub-id-type': 'isbn' }))
+  el.append(_createTextElement($$, node.issn, 'pub-id', { 'pub-id-type': 'issn' }))
   el.append(_createTextElement($$, node.doi, 'pub-id', { 'pub-id-type': 'doi' }))
   el.append(_createTextElement($$, node.pmid, 'pub-id', { 'pub-id-type': 'pmid' }))
   // creators

--- a/src/article/nodes/JournalArticleRef.js
+++ b/src/article/nodes/JournalArticleRef.js
@@ -39,5 +39,6 @@ JournalArticleRef.schema = {
   pageRange: STRING, // <page-range>
   elocationId: STRING, // <elocation-id>
   doi: STRING, // <pub-id pub-id-type="doi">
-  pmid: STRING // <pub-id pub-id-type="pmid">
+  pmid: STRING, // <pub-id pub-id-type="pmid">
+  issn: STRING // <pub-id pub-id-type="pmid">
 }

--- a/src/article/shared/EntityLabelsPackage.js
+++ b/src/article/shared/EntityLabelsPackage.js
@@ -98,6 +98,7 @@ export default {
     config.addLabel('given-names', 'Given Names')
     config.addLabel('inventors', 'Inventors')
     config.addLabel('isbn', 'ISBN')
+    config.addLabel('issn', 'ISSN')
     config.addLabel('issue', 'Issue')
     config.addLabel('issue-title', 'Issue Title')
     config.addLabel('lpage', 'Last Page')


### PR DESCRIPTION
## Why

ISSN field is needed in JournalArticleRef. 

## What
I just add ISSN field like ISBN in Books. 
Also in convertCSLJSON allow import CSLJSON files without DOIs, what are the problems in the further processing? everything seems to work ok in my local copy. 